### PR TITLE
Fix potential race condition in connection init.

### DIFF
--- a/src/server/netserver.h
+++ b/src/server/netserver.h
@@ -59,6 +59,7 @@ typedef struct {
 	int		sex;
 	int		stat_order[6];
 	client_setup_t	Client_setup;
+	bool broken_client;
 } connection_t;
 
 static void Contact(int fd, int arg);


### PR DESCRIPTION
There's a potential race condition here. If two people connect at the same time, the broken_client value may not be valid.