### PR TITLE
Fix format string issue in do_cmd_check_other (Fix #996)

### DIFF
--- a/src/server/cmd4.c
+++ b/src/server/cmd4.c
@@ -657,7 +657,7 @@ void do_cmd_check_other(int Ind, int line)
 	while (n < 128 && p_ptr->info[n] && strlen(p_ptr->info[n]))
 	{
 		/* Dump a line of info */
-		fprintf(fff, p_ptr->info[n]);
+		fprintf(fff, "%s" ,p_ptr->info[n]);
 
 		/* Newline */
 		fprintf(fff, "\n");


### PR DESCRIPTION
This fixes the unchecked format string insertion in multi-line files