### PR TITLE
Prevent integer overflow in infravision (Fix #1002). Also prevent ultimate infravision value from being negative, which has no meaning.

### DIFF
--- a/src/server/monster2.c
+++ b/src/server/monster2.c
@@ -1197,7 +1197,7 @@ void update_mon(int m_idx, bool dist)
 				if ((*w_ptr & CAVE_VIEW) && (!p_ptr->blind))
 				{
 					/* Use "infravision" */
-					if (m_ptr->cdis <= (byte)(p_ptr->see_infra))
+					if (m_ptr->cdis <= p_ptr->see_infra)
 					{
 						/* Infravision only works on "warm" creatures */
 						/* Below, we will need to know that infravision failed */
@@ -1431,7 +1431,7 @@ void update_player(int Ind)
 			
 			if (*w_ptr & CAVE_VIEW) {
 				/* Check infravision */
-				if (dis <= (byte)(p_ptr->see_infra))
+				if (dis <= p_ptr->see_infra)
 				{
 					/* Visible */
 					easy = flag = TRUE;

--- a/src/server/xtra1.c
+++ b/src/server/xtra1.c
@@ -2362,7 +2362,6 @@ static void calc_bonuses(int Ind)
 		if (object_known_p(Ind, o_ptr)) p_ptr->dis_to_d += o_ptr->to_d;
 	}
 
-	
 	/*** Handle stats ***/
 
 	/* Calculate stats */
@@ -2642,6 +2641,9 @@ static void calc_bonuses(int Ind)
 
 	/* Limit Skill -- digging from 1 up */
 	if (p_ptr->skill_dig < 1) p_ptr->skill_dig = 1;
+
+	/* Limit final infravision to >= 0 */
+	if(p_ptr->see_infra < 0) p_ptr->see_infra = 0;
 
 	/* Obtain the "hold" value */
 	hold = adj_str_hold[p_ptr->stat_ind[A_STR]];


### PR DESCRIPTION
Negative infravision was possible - this was then being cast incorrectly to an unsigned value, leading to the bug. As negative infravision serves no purpose and it looks incorrect on the character sheet, I have removed it.