### PR TITLE
Don't let the user pick up when paralysed. [Fix #945]

### DIFF
--- a/src/server/cmd1.c
+++ b/src/server/cmd1.c
@@ -644,6 +644,8 @@ void carry(int Ind, int pickup, int confirm)
 		if ((p_ptr->ghost) || (p_ptr->fruit_bat) ) return;
 	};
 
+	if(p_ptr->paralyzed) return;
+
 	/* Get the object */
 	o_ptr = &o_list[c_ptr->o_idx];
 


### PR DESCRIPTION
Ticket states that user should not be able to pick up item from floor when paralysed. This makes sense. Gaining spells cannot be done while paralysed, although it can be queued. It was not possible to take off worn items while paralysed.