### PR TITLE
Unset pointers after they have been freed; function could be called twice

### DIFF
--- a/src/client/net-client.c
+++ b/src/client/net-client.c
@@ -55,9 +55,11 @@ void setup_network_client()
 void cleanup_network_client()
 {
 	e_release_all(first_connection, 0, 1);
+	first_connection = NULL;
 	e_release_all(first_caller, 0, 1);
-
+	first_caller = NULL;
 	e_release_all(first_timer, 0, 1);
+	first_timer = NULL;
 }
 
 /* Iteration of the Loop */


### PR DESCRIPTION
On non-windows, the cleanup_network_client function may be called more than once. Calling it with the original, freed pointers will cause it to crash. Removing the cause of the double-call would be a good idea too.