### PR TITLE
Remove some use of format function within existing functions.

### DIFF
--- a/src/client/c-init.c
+++ b/src/client/c-init.c
@@ -477,7 +477,7 @@ void client_init(char *argv1)
 			case E_TWO_PLAYERS:
 				quit("There is already another character from this user/machine on the server.");
 			default:
-				quit(format("Connection failed with status %d.", status));
+				quit_fmt("Connection failed with status %d.", status);
 		}
 	}
 

--- a/src/client/maim-sdl.c
+++ b/src/client/maim-sdl.c
@@ -205,7 +205,7 @@ errr SDL_ScaleBlit(SDL_Surface *src, SDL_Rect *sr, SDL_Surface *dst, SDL_Rect *d
 			if (rs >= 256 || gs >= 256 || bs >= 256)
 			{
 				plog("fixed point weighted average overflow!");
-				plog(format("Values: %d, %d, %d\n", rs, gs, bs));
+				plog_fmt("Values: %d, %d, %d\n", rs, gs, bs);
 			}
 
 			r = (Uint8) rs;
@@ -345,7 +345,7 @@ errr SDL_StretchBlit(SDL_Surface *src, SDL_Rect *sr, SDL_Surface *dst, SDL_Rect 
 			if (r >= 256.0 || g >= 256.0 || b > 256.0) 
 			{
 				plog("mixing error!");
-				plog(format("Values: %f, %f, %f\n", (double)r, (double)g, (double)b));
+				plog_fmt("Values: %f, %f, %f\n", (double)r, (double)g, (double)b);
 				/**((char *)0) = 0;*/
 			}
 			if (r > 255.0) r = 255.0;

--- a/src/client/main-sdl.c
+++ b/src/client/main-sdl.c
@@ -261,8 +261,6 @@ void SDL_FillRectX(SDL_Surface *f, SDL_Rect *r, Uint32 color, int xoff, int yoff
 }
 
 void SDL_UpdateRectX(int x, int y, int w, int h, int xoff, int yoff) {
-//	plog(format("[???] updateRectXX: %d,%d -- %d,%d", x+xoff,y+yoff,w+xoff,h+yoff));
-//	SDL_UpdateRect(f, x, y, w, h);
 	if (x+xoff+w > width) w = width-xoff-x;
 	if (y+yoff+h > height) h = height-yoff-y;
 	SDL_UpdateRect(bigface, x+xoff, y+yoff, w, h);
@@ -393,7 +391,7 @@ errr load_HEX_font_sdl(font_data *fd, cptr filename, bool justmetrics)
 
 	if (!f) 
 	{
-		plog(format("Couldn't open: %s", buf));
+		plog_fmt("Couldn't open: %s", buf);
 		return -1;
 	}
 
@@ -1000,7 +998,7 @@ void RedrawChar(int x, int y)
 {
 	Uint8 a, c;
 
-	a = Term->scr->a[y][x];	c = Term->scr->c[y][x];
+	a = Term->scr->a[y][x];	c = Term->scr->c[y][x];
 	
 	//Term_wipe_sdl(x, y, 1);
 	Term_char_sdl(x, y, a, c);
@@ -1207,20 +1205,6 @@ inline static errr Term_tile_sdl (int x, int y, Uint8 a, Uint8 c){
 	dr.x = x * td->w;
 	dr.y = y * td->h;
 
-	if (sr.x > td->gt->face->w)
-	{
-/*
-		SDL_FillRectX(td->face, &dr, SDL_MapRGB(td->face->format, 255, 64, 64), td->xoff, td->yoff);
-		plog(format("OOBound (%d, %d) (%d, %d bitmap)", c&0x7f, a&0x7f, sr.x, sr.y)); 
-?????
-*/
-	} else
-	{
-/*
-		SDL_BlitSurface(td->gt->face, &sr, td->face, &dr);
-?????
-*/
-	}
 	if (td->cx == x && td->cy == y)
 	{
 		SDL_UpdateRectX( dr.x, dr.y, dr.w, dr.h, td->xoff, td->yoff);
@@ -1369,10 +1353,6 @@ static void term_data_link(int i)
 
 	term_data *td = &(data[i]);
 	term *t = &(td->t);
-
-
-
-/*	plog(format("setting up data link for term %d (%s) add %d",i,td->name,t)); */
 
 	int j = 0;
 	if (i == 0) j = 256;
@@ -1794,7 +1774,7 @@ errr init_sdl(int oargc, char **oargv)
 				asked[199] = 0;
 				strncpy(got, formatsdlflags(bigface->flags), 199);
 				got[199] = 0;
-				plog(format("Vid. init.: We asked for %s and got %s", asked, got));
+				plog_fmt("Vid. init.: We asked for %s and got %s", asked, got);
 			}
 
 
@@ -1823,10 +1803,9 @@ errr init_sdl(int oargc, char **oargv)
 	if (strtoii(tilebmpname, &gw, &gh))
 	{
 		// strtoii() has failed. keep the (likely wrong) default */
-		plog(format("strtoii() failed for %s", tilebmpname));
+		plog_fmt("strtoii() failed for %s", tilebmpname);
 	} else
 	{
-		/*plog(format("%s yielded %d, %d by strtoii()", tilebmpname, gw, gh));*/
 		screen_tiles.w = screen_tiles.dw = gw;
 		screen_tiles.h = screen_tiles.dh = gh;
 		/* This will enlarge the window tile size to fit all elements.
@@ -1905,7 +1884,7 @@ errr init_sdl(int oargc, char **oargv)
 
 	if((screen_tiles.face = SDL_LoadBMP(path)) == NULL)
 	{
-		plog(format("Sorry, could not load %s", path));
+		plog_fmt("Sorry, could not load %s", path);
 	} else
 	{
 		td->t.higher_pict = use_graphics;

--- a/src/client/netclient.c
+++ b/src/client/netclient.c
@@ -338,13 +338,13 @@ int Net_verify(char *real, char *nick, char *pass, int sex, int race, int class)
 	if (type != PKT_VERIFY)
 	{
 		errno = 0;
-		plog(format("Verify wrong reply type (%d)", type));
+		plog_fmt("Verify wrong reply type (%d)", type);
 		return -1;
 	}
 	if (result != PKT_SUCCESS)
 	{
 		errno = 0;
-		plog(format("Verification failed (%d)", result));
+		plog_fmt("Verification failed (%d)", result);
 		return -1;
 	}
 	if (Receive_magic() <= 0)
@@ -390,16 +390,16 @@ int Net_init(char *server, int fd)
 	}
 
 	if (SetSocketSendBufferSize(sock, CLIENT_SEND_SIZE + 256) == -1)
-		plog(format("Can't set send buffer size to %d: error %d", CLIENT_SEND_SIZE + 256, errno));
+		plog_fmt("Can't set send buffer size to %d: error %d", CLIENT_SEND_SIZE + 256, errno);
 	if (SetSocketReceiveBufferSize(sock, CLIENT_RECV_SIZE + 256) == -1)
-		plog(format("Can't set receive buffer size to %d", CLIENT_RECV_SIZE + 256));
+		plog_fmt("Can't set receive buffer size to %d", CLIENT_RECV_SIZE + 256);
 
 
 	/* reliable data buffer, not a valid socket filedescriptor needed */
 	if (Sockbuf_init(&cbuf, -1, CLIENT_RECV_SIZE,
 		SOCKBUF_WRITE | SOCKBUF_READ | SOCKBUF_LOCK) == -1)
 	{
-		plog(format("No memory for control buffer (%u)", CLIENT_RECV_SIZE));
+		plog_fmt("No memory for control buffer (%u)", CLIENT_RECV_SIZE);
 		return -1;
 	}
 
@@ -407,7 +407,7 @@ int Net_init(char *server, int fd)
 	if (Sockbuf_init(&qbuf, -1, CLIENT_RECV_SIZE,
 		SOCKBUF_WRITE | SOCKBUF_READ | SOCKBUF_LOCK) == -1)
 	{
-		plog(format("No memory for queue buffer (%u)", CLIENT_RECV_SIZE));
+		plog_fmt("No memory for queue buffer (%u)", CLIENT_RECV_SIZE);
 		return -1;
 	}
 
@@ -416,7 +416,7 @@ int Net_init(char *server, int fd)
 	if (Sockbuf_init(&rbuf, sock, CLIENT_RECV_SIZE,
 		SOCKBUF_READ | SOCKBUF_DGRAM) == -1)
 	{
-		plog(format("No memory for read buffer (%u)", CLIENT_RECV_SIZE));
+		plog_fmt("No memory for read buffer (%u)", CLIENT_RECV_SIZE);
 		return -1;
 	}
 
@@ -424,7 +424,7 @@ int Net_init(char *server, int fd)
 	if (Sockbuf_init(&wbuf, sock, CLIENT_SEND_SIZE,
 		SOCKBUF_WRITE | SOCKBUF_DGRAM) == -1)
 	{
-		plog(format("No memory for write buffer (%u)", CLIENT_SEND_SIZE));
+		plog_fmt("No memory for write buffer (%u)", CLIENT_SEND_SIZE);
 		return -1;
 	}
 #endif
@@ -432,7 +432,7 @@ int Net_init(char *server, int fd)
 	if (Sockbuf_init(&rbuf, sock, CLIENT_RECV_SIZE,
 		SOCKBUF_READ | SOCKBUF_WRITE) == -1)
 	{
-		plog(format("No memory for read buffer (%u)", CLIENT_RECV_SIZE));
+		plog_fmt("No memory for read buffer (%u)", CLIENT_RECV_SIZE);
 		return -1;
 	}
 
@@ -440,7 +440,7 @@ int Net_init(char *server, int fd)
 	if (Sockbuf_init(&wbuf, sock, CLIENT_SEND_SIZE,
 		SOCKBUF_WRITE) == -1)
 	{
-		plog(format("No memory for write buffer (%u)", CLIENT_SEND_SIZE));
+		plog_fmt("No memory for write buffer (%u)", CLIENT_SEND_SIZE);
 		return -1;
 	}
 
@@ -645,7 +645,7 @@ int Net_packet(void)
 			errno = 0;
 			/* The player really doesn't need to know about this */
 #ifdef DEBUG			
-			plog(format("Received unknown packet type (%d, %d), dropping", type, prev_type));
+			plog_fmt("Received unknown packet type (%d, %d), dropping", type, prev_type);
 #endif
 			Sockbuf_clear(&rbuf);
 			break;
@@ -657,7 +657,7 @@ int Net_packet(void)
 				if (type != PKT_QUIT)
 				{
 					errno = 0;
-					plog(format("Processing packet type (%d, %d) failed", type, prev_type));
+					plog_fmt("Processing packet type (%d, %d) failed", type, prev_type);
 				}
 				return -1;
 			}
@@ -683,13 +683,13 @@ int Net_packet(void)
 				return -1;
 			}
 			errno = 0;
-			plog(format("Got reply packet (%d, %d)", replyto, status));
+			plog_fmt("Got reply packet (%d, %d)", replyto, status);
 		}
 		else if (receive_tbl[type] == NULL)
 		{
 			errno = 0;
-			 //plog(format("Receive unknown reliable data packet type (%d, %d, %d)",
-			//	type, cbuf.ptr - cbuf.buf, cbuf.len)); 
+			 //plog_fmt("Receive unknown reliable data packet type (%d, %d, %d)",
+			//	type, cbuf.ptr - cbuf.buf, cbuf.len);
 
 			 /* we have received bad data, ignore this packet */
 			Sockbuf_clear(&cbuf);
@@ -926,14 +926,14 @@ int old_Receive_reliable(void)
 	if (len <= 0)
 	{
 		errno = 0;
-		plog(format("Bad reliable data length (%d)", len));
+		plog_fmt("Bad reliable data length (%d)", len);
 		return -1;
 	}
 
 	if (full_len <= 0)
 	{
 		errno = 0;
-		plog(format("Bad reliable data full length (%d)", reliable_full_len));
+		plog_fmt("Bad reliable data full length (%d)", reliable_full_len);
 		return -1;
 	}
 
@@ -948,8 +948,8 @@ int old_Receive_reliable(void)
 	if (rbuf.ptr + len > rbuf.buf + rbuf.len)
 	{
 		errno = 0;
-		plog(format("Not all reliable data in packet (%d, %d, %d)",
-			rbuf.ptr - rbuf.buf, len, rbuf.len));
+		plog_fmt("Not all reliable data in packet (%d, %d, %d)",
+			rbuf.ptr - rbuf.buf, len, rbuf.len);
 		rbuf.ptr += len;
 		Sockbuf_advance(&rbuf, rbuf.ptr - rbuf.buf);
 		return -1;

--- a/src/client/netclient.c
+++ b/src/client/netclient.c
@@ -571,8 +571,8 @@ int Net_start(void)
 	if (cbuf.ptr[0] != PKT_REPLY)
 	{
 		errno = 0;
-		quit(format("Not a reply packet after play (%d,%d,%d)",
-			cbuf.ptr[0], cbuf.ptr - cbuf.buf, cbuf.len));
+		quit_fmt("Not a reply packet after play (%d,%d,%d)",
+			cbuf.ptr[0], cbuf.ptr - cbuf.buf, cbuf.len);
 		return -1;
 	}
 	if (Receive_reply(&type, &result) <= 0)
@@ -590,7 +590,7 @@ int Net_start(void)
 	if (result != PKT_SUCCESS)
 	{
 		errno = 0;
-		quit(format("Start play not allowed (%d)", result));
+		quit_fmt("Start play not allowed (%d)", result);
 		return -1;
 	}
 	// Finish processing any commands that were sent to us along with
@@ -1044,7 +1044,7 @@ int Receive_quit(void)
 		if (Packet_scanf(sbuf, "%s", reason) <= 0)
 			strcpy(reason, "unknown reason");
 		errno = 0;
-		quit(format("Quitting: %s", reason));
+		quit_fmt("Quitting: %s", reason);
 	}
 	return -1;
 }

--- a/src/common/net-unix.c
+++ b/src/common/net-unix.c
@@ -1454,7 +1454,7 @@ int	port;
     if (retval < 0)
     {
 	sl_errno = SL_EBIND;
-	plog(format("Dgram Socket Bind Error: %d,%d",retval,errno));
+	plog_fmt("Dgram Socket Bind Error: %d,%d",retval,errno);
 	retval = errno;
 	(void) close(fd);
 	errno = retval;

--- a/src/common/sockbuf.c
+++ b/src/common/sockbuf.c
@@ -125,7 +125,7 @@ int Sockbuf_advance(sockbuf_t *sbuf, int len)
     if (len <= 0) {
 	if (len < 0) {
 	    errno = 0;
-	    plog(format("Sockbuf advance negative (%d)", len));
+	    plog_fmt("Sockbuf advance negative (%d)", len);
 	}
     }
     else if (len >= sbuf->len) {
@@ -159,14 +159,14 @@ int Sockbuf_flush(sockbuf_t *sbuf)
     if (BIT(sbuf->state, SOCKBUF_WRITE) == 0) {
 	errno = 0;
 	plog("No flush on non-writable socket buffer");
-	plog(format("(state=%02x,buf=%08x,ptr=%08x,size=%d,len=%d,sock=%d)",
+	plog_fmt("(state=%02x,buf=%08x,ptr=%08x,size=%d,len=%d,sock=%d)",
 	    sbuf->state, sbuf->buf, sbuf->ptr, sbuf->size, sbuf->len,
-	    sbuf->sock));
+	    sbuf->sock);
 	return -1;
     }
     if (BIT(sbuf->state, SOCKBUF_LOCK) != 0) {
 	errno = 0;
-	plog(format("No flush on locked socket buffer (0x%02x)", sbuf->state));
+	plog_fmt("No flush on locked socket buffer (0x%02x)", sbuf->state);
 	return -1;
     }
     if (sbuf->len <= 0) {
@@ -223,13 +223,13 @@ int Sockbuf_flush(sockbuf_t *sbuf)
 	    }
 #endif
 	    if (++i > MAX_SOCKBUF_RETRIES) {
-		plog(format("Can't send on socket (%d,%d)", sbuf->sock, sbuf->len));
+		plog_fmt("Can't send on socket (%d,%d)", sbuf->sock, sbuf->len);
 		Sockbuf_clear(sbuf);
 		return -1;
 	    }
 	    { static int send_err;
 		if ((send_err++ & 0x3F) == 0) {
-		    /*plog(format("send (%d)", i));*/
+		    /*plog_fmt("send (%d)", i);*/
 		}
 	    }
 	    if (GetSocketError(sbuf->sock) == -1) {
@@ -240,7 +240,7 @@ int Sockbuf_flush(sockbuf_t *sbuf)
 	}
 	if (len != sbuf->len) {
 	    errno = 0;
-	    plog(format("Can't write complete datagram (%d,%d)", len, sbuf->len));
+	    plog_fmt("Can't write complete datagram (%d,%d)", len, sbuf->len);
 	}
 	Sockbuf_clear(sbuf);
     } else {
@@ -272,8 +272,8 @@ int Sockbuf_write(sockbuf_t *sbuf, char *buf, int len)
     if (sbuf->size - sbuf->len < len) {
 	if (BIT(sbuf->state, SOCKBUF_LOCK | SOCKBUF_DGRAM) != 0) {
 	    errno = 0;
-	    plog(format("No write to locked socket buffer (%d,%d,%d,%d)",
-		sbuf->state, sbuf->size, sbuf->len, len));
+	    plog_fmt("No write to locked socket buffer (%d,%d,%d,%d)",
+		sbuf->state, sbuf->size, sbuf->len, len);
 	    return -1;
 	}
 	if (Sockbuf_flush(sbuf) == -1) {
@@ -297,7 +297,7 @@ int Sockbuf_read(sockbuf_t *sbuf)
 
     if (BIT(sbuf->state, SOCKBUF_READ) == 0) {
 	errno = 0;
-	plog(format("No read from non-readable socket buffer (%d)", sbuf->state));
+	plog_fmt("No read from non-readable socket buffer (%d)", sbuf->state);
 	return -1;
     }
     if (BIT(sbuf->state, SOCKBUF_LOCK) != 0) {
@@ -310,8 +310,8 @@ int Sockbuf_read(sockbuf_t *sbuf)
 	static int before;
 	if (before++ == 0) {
 	    errno = 0;
-	    plog(format("Read socket buffer not big enough (%d,%d)",
-		  sbuf->size, sbuf->len));
+	    plog_fmt("Read socket buffer not big enough (%d,%d)",
+		  sbuf->size, sbuf->len);
 	}
 	return -1;
     }
@@ -347,7 +347,7 @@ int Sockbuf_read(sockbuf_t *sbuf)
 	    }
 	    { static int recv_err;
 		if ((recv_err++ & 0x3F) == 0) {
-		    /*plog(format("recv (%d)", i));*/
+		    /*plog_fmt("recv (%d)", i);*/
 		}
 	    }
 	    if (GetSocketError(sbuf->sock) == -1) {
@@ -578,7 +578,7 @@ int Packet_printf(va_alist)
 	}
 	else if (failure == PRINTF_FMT) {
 	    errno = 0;
-	    plog(format("Error in format string (\"%s\")", fmt));
+	    plog_fmt("Error in format string (\"%s\")", fmt);
 	}
     } else {
 	count = buf - (sbuf->buf + sbuf->len);
@@ -791,8 +791,8 @@ int Packet_scanf(va_alist)
 			    /*
 #ifndef SILENT
 			errno = 0;
-			plog(format("String overflow while scanning (%d,%d)",
-			      k, max_str_size));
+			plog_fmt("String overflow while scanning (%d,%d)",
+			      k, max_str_size);
 #endif
 			if (BIT(sbuf->state, SOCKBUF_LOCK) != 0) {
 			    failure = 2;
@@ -820,7 +820,7 @@ int Packet_scanf(va_alist)
     }
     if (failure == 1) {
 	errno = 0;
-	plog(format("Error in format string (%s)", fmt));
+	plog_fmt("Error in format string (%s)", fmt);
     }
     else if (failure == 3) {
 	/* Not enough input for one complete packet */
@@ -830,7 +830,7 @@ int Packet_scanf(va_alist)
     else if (failure == 0) {
 	if (&sbuf->buf[sbuf->len] < &sbuf->ptr[j]) {
 	    errno = 0;
-	    plog(format("Input buffer exceeded (%s)", fmt));
+	    plog_fmt("Input buffer exceeded (%s)", fmt);
 	    failure = 1;
 	} else {
 	    sbuf->ptr += j;

--- a/src/common/z-form.c
+++ b/src/common/z-form.c
@@ -703,32 +703,6 @@ uint strnfmt(char *buf, uint max, cptr fmt, ...)
 
 
 /*
- * Do a vstrnfmt (see above) into a buffer of unknown size.
- * Since the buffer size is unknown, the user better verify the args.
- */
-uint strfmt(char *buf, cptr fmt, ...)
-{
-	uint len;
-
-	va_list vp;
-
-	/* Begin the Varargs Stuff */
-	va_start(vp, fmt);
-
-	/* Build the string, assume 32K buffer */
-	len = vstrnfmt(buf, 32767, fmt, vp);
-
-	/* End the Varargs Stuff */
-	va_end(vp);
-
-	/* Return the number of bytes written */
-	return (len);
-}
-
-
-
-
-/*
  * Do a vstrnfmt() into (see above) into a (growable) static buffer.
  * This buffer is usable for very short term formatting of results.
  * Note that the buffer is (technically) writable, but only up to
@@ -753,27 +727,26 @@ char *format(cptr fmt, ...)
 }
 
 
-
-
 /*
  * Vararg interface to plog()
  */
 void plog_fmt(cptr fmt, ...)
 {
-	char *res;
+	const size_t format_len = 512;
+	char format_buf[format_len];
 	va_list vp;
 
 	/* Begin the Varargs Stuff */
 	va_start(vp, fmt);
 
 	/* Format the args */
-	res = vformat(fmt, vp);
+	uint len = vstrnfmt(format_buf, format_len, fmt, vp);
 
 	/* End the Varargs Stuff */
 	va_end(vp);
 
 	/* Call plog */
-	plog(res);
+	plog(format_buf);
 }
 
 
@@ -783,41 +756,21 @@ void plog_fmt(cptr fmt, ...)
  */
 void quit_fmt(cptr fmt, ...)
 {
-	char *res;
+	const size_t format_len = 512;
+	char format_buf[format_len];
+
 	va_list vp;
 
 	/* Begin the Varargs Stuff */
 	va_start(vp, fmt);
 
 	/* Format */
-	res = vformat(fmt, vp);
+	uint len = vstrnfmt(format_buf, format_len, fmt, vp);
 
 	/* End the Varargs Stuff */
 	va_end(vp);
 
 	/* Call quit() */
-	quit(res);
+	quit(format_buf);
 }
 
-
-
-/*
- * Vararg interface to core()
- */
-void core_fmt(cptr fmt, ...)
-{
-	char *res;
-	va_list vp;
-
-	/* Begin the Varargs Stuff */
-	va_start(vp, fmt);
-
-	/* If requested, Do a virtual fprintf to stderr */
-	res = vformat(fmt, vp);
-
-	/* End the Varargs Stuff */
-	va_end(vp);
-
-	/* Call core() */
-	core(res);
-}

--- a/src/common/z-form.h
+++ b/src/common/z-form.h
@@ -25,9 +25,6 @@ extern uint vstrnfmt(char *buf, uint max, cptr fmt, va_list vp);
 /* Simple interface to "vstrnfmt()" */
 extern uint strnfmt(char *buf, uint max, cptr fmt, ...);
 
-/* Simple interface to "vstrnfmt()", assuming infinite length */
-extern uint strfmt(char *buf, cptr fmt, ...);
-
 /* Format arguments into a static resizing buffer */
 extern char *vformat(cptr fmt, va_list vp);
 
@@ -39,9 +36,5 @@ extern void plog_fmt(cptr fmt, ...);
 
 /* Vararg interface to "quit()", using "format()" */
 extern void quit_fmt(cptr fmt, ...);
-
-/* Vararg interface to "core()", using "format()" */
-extern void core_fmt(cptr fmt, ...);
-
 
 #endif

--- a/src/server/cmd4.c
+++ b/src/server/cmd4.c
@@ -273,7 +273,7 @@ void do_cmd_check_artifacts(int Ind, int line)
 	/* Paranoia */
 	if (!fff) 
 	{
-		plog(format("ERROR! %s (writing %s)", strerror(errno), file_name));
+		plog_fmt("ERROR! %s (writing %s)", strerror(errno), file_name);
 		return;
 	}
 
@@ -420,7 +420,7 @@ void do_cmd_check_uniques(int Ind, int line)
 	/* Paranoia */
 	if (!fff) 
 	{
-		plog(format("ERROR! %s (writing %s)", strerror(errno), file_name));
+		plog_fmt("ERROR! %s (writing %s)", strerror(errno), file_name);
 		return;
 	}
 
@@ -548,7 +548,7 @@ void do_cmd_check_players(int Ind, int line)
 	/* Paranoia */
 	if (!fff) 
 	{
-		plog(format("ERROR! %s (writing %s)", strerror(errno), file_name));
+		plog_fmt("ERROR! %s (writing %s)", strerror(errno), file_name);
 		return;
 	}
 
@@ -649,7 +649,7 @@ void do_cmd_check_other(int Ind, int line)
 	/* Paranoia */
 	if (!fff) 
 	{
-		plog(format("ERROR! %s (writing %s)", strerror(errno), file_name));
+		plog_fmt("ERROR! %s (writing %s)", strerror(errno), file_name);
 		return;
 	}
 

--- a/src/server/control.c
+++ b/src/server/control.c
@@ -353,7 +353,7 @@ void NewConsole(int read_fd, int arg)
 			DgramWrite(read_fd, console_buf.buf, console_buf.len);
 
 			/* Log this to the local console */
-			plog(format("Illegal console command from %s.", DgramLastname()));
+			plog_fmt("Illegal console command from %s.", DgramLastname());
 
 			return;
 		}

--- a/src/server/files.c
+++ b/src/server/files.c
@@ -496,7 +496,7 @@ errr process_pref_file(cptr name)
 		if (process_pref_file_aux(buf))
 		{
 			/* Useful error message */
-			plog(format("Error in '%s' parsing '%s'.", buf, name));
+			plog_fmt("Error in '%s' parsing '%s'.", buf, name);
 		}
 	}
 
@@ -2547,7 +2547,7 @@ static void display_scores_aux(int Ind, int line, int note, high_score *score)
 	/* Paranoia */
 	if (!fff) 
 	{
-		plog(format("ERROR! %s (writing %s)", strerror(errno), file_name));
+		plog_fmt("ERROR! %s (writing %s)", strerror(errno), file_name);
 		return;
 	}
 

--- a/src/server/generate.c
+++ b/src/server/generate.c
@@ -4487,7 +4487,7 @@ void generate_cave(int Ind, int Depth, int auto_scum)
 
 
 		/* Message */
-		if (why) plog(format("Generation restarted (%s)", why));
+		if (why) plog_fmt("Generation restarted (%s)", why);
 
 		/* Wipe the objects */
 		wipe_o_list(Depth);

--- a/src/server/init1.c
+++ b/src/server/init1.c
@@ -2049,7 +2049,7 @@ static errr grab_one_kind_flag(object_kind *k_ptr, cptr what)
     */
 
 	/* Oops */
-	plog(format("Unknown object flag '%s'.", what));
+	plog_fmt("Unknown object flag '%s'.", what);
 
 	/* Error */
 	return (1);
@@ -2414,7 +2414,7 @@ static errr grab_one_artifact_flag(artifact_type *a_ptr, cptr what)
     */
 
 	/* Oops */
-	plog(format("Unknown artifact flag '%s'.", what));
+	plog_fmt("Unknown artifact flag '%s'.", what);
 
 	/* Error */
 	return (1);
@@ -2438,7 +2438,7 @@ static errr grab_one_activation(artifact_type *a_ptr, cptr what)
 	}
 
 	/* Oops */
-	plog(format("Unknown artifact activation '%s'.", what));
+	plog_fmt("Unknown artifact activation '%s'.", what);
 
 	/* Error */
 	return (1);
@@ -2776,7 +2776,7 @@ static bool grab_one_ego_item_flag(ego_item_type *e_ptr, cptr what)
     */
 
 	/* Oops */
-	plog(format("Unknown ego-item flag '%s'.", what));
+	plog_fmt("Unknown ego-item flag '%s'.", what);
 
 	/* Error */
 	return (1);
@@ -3084,7 +3084,7 @@ static errr grab_one_basic_flag(monster_race *r_ptr, cptr what)
 	}
 
 	/* Oops */
-	plog(format("Unknown monster flag '%s'.", what));
+	plog_fmt("Unknown monster flag '%s'.", what);
 
 	/* Failure */
 	return (1);
@@ -3129,7 +3129,7 @@ static errr grab_one_spell_flag(monster_race *r_ptr, cptr what)
 	}
 
 	/* Oops */
-	plog(format("Unknown monster flag '%s'.", what));
+	plog_fmt("Unknown monster flag '%s'.", what);
 
 	/* Failure */
 	return (1);

--- a/src/server/init2.c
+++ b/src/server/init2.c
@@ -530,9 +530,9 @@ static void display_parse_error(cptr filename, errr err, cptr buf)
 	oops = (((err > 0) && (err < PARSE_ERROR_MAX)) ? err_str[err] : "unknown");
 
 	/* Oops */
-	plog(format("Error at line %d of '%s.txt'.", error_line, filename));
-	plog(format("Record %d contains a '%s' error.", error_idx, oops));
-	plog(format("Parsing '%s'.", buf));
+	plog_fmt("Error at line %d of '%s.txt'.", error_line, filename);
+	plog_fmt("Record %d contains a '%s' error.", error_idx, oops);
+	plog_fmt("Parsing '%s'.", buf);
 /*	message_flush();*/
 
 	/* Quit */
@@ -872,9 +872,9 @@ static errr init_f_info(void)
 		oops = (((err > 0) && (err < 8)) ? err_str[err] : "unknown");
 
 		/* Oops */
-		plog(format("Error %d at line %d of 'terrain.txt'.", err, error_line));
-		plog(format("Record %d contains a '%s' error.", error_idx, oops));
-		plog(format("Parsing '%s'.", buf));
+		plog_fmt("Error %d at line %d of 'terrain.txt'.", err, error_line);
+		plog_fmt("Record %d contains a '%s' error.", error_idx, oops);
+		plog_fmt("Parsing '%s'.", buf);
 		/*msg_print(NULL);*/
 
 		/* Quit */
@@ -970,9 +970,9 @@ static errr init_k_info(void)
 		oops = (((err > 0) && (err < 8)) ? err_str[err] : "unknown");
 
 		/* Oops */
-		plog(format("Error %d at line %d of 'object.txt'.", err, error_line));
-		plog(format("Record %d contains a '%s' error.", error_idx, oops));
-		plog(format("Parsing '%s'.", buf));
+		plog_fmt("Error %d at line %d of 'object.txt'.", err, error_line);
+		plog_fmt("Record %d contains a '%s' error.", error_idx, oops);
+		plog_fmt("Parsing '%s'.", buf);
 		/*msg_print(NULL);*/
 
 		/* Quit */
@@ -1061,9 +1061,9 @@ static errr init_a_info(void)
 		oops = (((err > 0) && (err < 8)) ? err_str[err] : "unknown");
 
 		/* Oops */
-		plog(format("Error %d at line %d of 'artifact.txt'.", err, error_line));
-		plog(format("Record %d contains a '%s' error.", error_idx, oops));
-		plog(format("Parsing '%s'.", buf));
+		plog_fmt("Error %d at line %d of 'artifact.txt'.", err, error_line);
+		plog_fmt("Record %d contains a '%s' error.", error_idx, oops);
+		plog_fmt("Parsing '%s'.", buf);
 		/*msg_print(NULL);*/
 
 		/* Quit */
@@ -1209,9 +1209,9 @@ static errr init_e_info(void)
 		oops = (((err > 0) && (err < 8)) ? err_str[err] : "unknown");
 
 		/* Oops */
-		plog(format("Error %d at line %d of 'ego_item.txt'.", err, error_line));
-		plog(format("Record %d contains a '%s' error.", error_idx, oops));
-		plog(format("Parsing '%s'.", buf));
+		plog_fmt("Error %d at line %d of 'ego_item.txt'.", err, error_line);
+		plog_fmt("Record %d contains a '%s' error.", error_idx, oops);
+		plog_fmt("Parsing '%s'.", buf);
 		/*msg_print(NULL);*/
 
 		/* Quit */
@@ -1298,9 +1298,9 @@ static errr init_r_info(void)
 		oops = (((err > 0) && (err < 8)) ? err_str[err] : "unknown");
 
 		/* Oops */
-		plog(format("Error %d at line %d of 'monster.txt'.", err, error_line));
-		plog(format("Record %d contains a '%s' error.", error_idx, oops));
-		plog(format("Parsing '%s'.", buf));
+		plog_fmt("Error %d at line %d of 'monster.txt'.", err, error_line);
+		plog_fmt("Record %d contains a '%s' error.", error_idx, oops);
+		plog_fmt("Parsing '%s'.", buf);
 		/*msg_print(NULL);*/
 
 		/* Quit */
@@ -1397,9 +1397,9 @@ static errr init_v_info(void)
 		oops = (((err > 0) && (err < 8)) ? err_str[err] : "unknown");
 
 		/* Oops */
-		plog(format("Error %d at line %d of 'vault.txt'.", err, error_line));
-		plog(format("Record %d contains a '%s' error.", error_idx, oops));
-		plog(format("Parsing '%s'.", buf));
+		plog_fmt("Error %d at line %d of 'vault.txt'.", err, error_line);
+		plog_fmt("Record %d contains a '%s' error.", error_idx, oops);
+		plog_fmt("Parsing '%s'.", buf);
 		/*msg_print(NULL);*/
 
 		/* Quit */
@@ -2394,7 +2394,7 @@ void set_server_option(char * option, char * value)
 	else if (!strcmp(option,"DUNGEON_MASTER_NAME"))
 	{
 		cfg_dungeon_master = strdup(value);
-	plog(format("Dugeon Master Set as [%s]",cfg_dungeon_master));
+	plog_fmt("Dungeon Master Set as [%s]",cfg_dungeon_master);
     }
 	else if (!strcmp(option,"SECRET_DUNGEON_MASTER"))
 	{
@@ -2485,7 +2485,7 @@ void set_server_option(char * option, char * value)
     }
 
 
-	else plog(format("Error : unrecognized mangband.cfg option %s", option));
+	else plog_fmt("Error : unrecognized mangband.cfg option %s", option);
 }
 
 
@@ -2572,7 +2572,7 @@ void load_server_cfg(void)
 		return;
 	}
 
-	plog(format("Loading %s", possible_cfg_dir[i-1]));
+	plog_fmt("Loading %s", possible_cfg_dir[i-1]);
 
 	/* Actually parse the file */
 	load_server_cfg_aux(cfg);

--- a/src/server/init2.c
+++ b/src/server/init2.c
@@ -612,7 +612,7 @@ static errr init_info(cptr filename, header *head)
 		fp = my_fopen(buf, "r");
 
 		/* Parse it */
-		if (!fp) quit(format("Cannot open '%s' file.", buf));
+		if (!fp) quit_fmt("Cannot open '%s' file.", buf);
 
 		/* Parse the file */
 		err = init_info_txt(fp, buf, head, head->parse_info_txt);
@@ -730,7 +730,7 @@ static errr init_info(cptr filename, header *head)
 		fd = fd_open(buf, O_RDONLY);
 
 		/* Process existing "raw" file */
-		if (fd < 0) quit(format("Cannot load '%s.raw' file.", filename));
+		if (fd < 0) quit_fmt("Cannot load '%s.raw' file.", filename);
 
 		/* Attempt to parse the "raw" file */
 		err = init_info_raw(fd, head);
@@ -739,7 +739,7 @@ static errr init_info(cptr filename, header *head)
 		fd_close(fd);
 
 		/* Error */
-		if (err) quit(format("Cannot parse '%s.raw' file.", filename));
+		if (err) quit_fmt("Cannot parse '%s.raw' file.", filename);
 
 #ifdef ALLOW_TEMPLATES
 	}

--- a/src/server/init2.c
+++ b/src/server/init2.c
@@ -364,22 +364,6 @@ void show_news(void)
 }
 
 
-
-/*
- * Hack -- take notes on line 23
- */
-#if 0
-static void note(cptr str)
-{
-	Term_erase(0, 23, 255);
-	Term_putstr(20, 23, -1, TERM_WHITE, str);
-	Term_fresh();
-}
-#endif
-
-
-
-
 #ifdef ALLOW_TEMPLATES
 
 

--- a/src/server/load2.c
+++ b/src/server/load2.c
@@ -337,27 +337,6 @@ bool section_exists(char* name)
 }
 
 /*
- * Show information on the screen, one line at a time.
- * Start at line 2, and wrap, if needed, back to line 2.
- */
-static void note(cptr msg)
-{
-#if 0
-	static int y = 2;
-
-	/* Draw the message */
-	prt(msg, y, 0);
-
-	/* Advance one line (wrap if needed) */
-	if (++y >= 24) y = 2;
-
-	/* Flush it */
-	Term_fresh();
-#endif
-}
-
-
-/*
  * Hack -- determine if an item is "wearable" (or a missile)
  */
 static bool wearable_p(object_type *o_ptr)
@@ -1146,7 +1125,7 @@ static errr rd_inventory(int Ind)
 		else if (p_ptr->inven_cnt == INVEN_PACK)
 		{
 			/* Oops */
-			/*note("Too many items in the inventory!");*/
+			plog("Too many items in the inventory!");
 
 			/* Fail */
 			return (54);
@@ -1364,7 +1343,7 @@ static errr rd_dungeon_special()
 			/* we have an arbitrary max number of levels */
 			if(num_levels > MAX_SPECIAL_LEVELS)
 			{
-				note("Too many special pre-designed level files!");
+				plog("Too many special pre-designed level files!");
 				break;
 			}
 		}
@@ -1461,7 +1440,7 @@ static errr rd_savefile_new_aux(int Ind)
 	/* Incompatible save files */
 	if (tmp16u > MAX_K_IDX)
 	{
-		note(format("Too many (%u) object kinds!", tmp16u));
+		plog_fmt("Too many (%u) object kinds!", tmp16u);
 		return (22);
 	}
 
@@ -1477,13 +1456,9 @@ static errr rd_savefile_new_aux(int Ind)
 	}
 	end_section_read("object_memory");
 
-	/*if (arg_fiddle) note("Loaded Object Memory");*/
-
 	/* Read the extra stuff */
 	if (rd_extra(Ind))
 		return BAD_PASSWORD;
-	/*if (arg_fiddle) note("Loaded extra information");*/
-
 
 	/* Read the player_hp array */
 	start_section_read("hp");
@@ -1524,7 +1499,7 @@ static errr rd_savefile_new_aux(int Ind)
 	/* Read the inventory */
 	if (rd_inventory(Ind))
 	{
-		/*note("Unable to read inventory");*/
+		plog("Unable to read inventory");
 		return (21);
 	}
 
@@ -1687,7 +1662,7 @@ errr rd_server_savefile()
         /* Incompatible save files */
         if (tmp16u > MAX_R_IDX)
         {
-                note(format("Too many (%u) monster races!", tmp16u));
+                plog_fmt("Too many (%u) monster races!", tmp16u);
                 return (21);
         }
 
@@ -1713,7 +1688,7 @@ errr rd_server_savefile()
         /* Incompatible save files */
         if (tmp16u > MAX_A_IDX)
         {
-                note(format("Too many (%u) artifacts!", tmp16u));
+                plog_fmt("Too many (%u) artifacts!", tmp16u);
                 return (24);
         }
 
@@ -1741,7 +1716,7 @@ errr rd_server_savefile()
 		/* Incompatible save files */
 		if (tmp16u > MAX_PARTIES)
 		{
-			note(format("Too many (%u) parties!", tmp16u));
+			plog_fmt("Too many (%u) parties!", tmp16u);
 			return (25);
 		}
 
@@ -1768,7 +1743,7 @@ errr rd_server_savefile()
 		tmp32u = read_int("max_monsters");
 		if (tmp32u > MAX_M_IDX)
 		{
-			note(format("Too many (%u) monsters!", tmp16u));
+			plog_fmt("Too many (%u) monsters!", tmp16u);
 			return (29);
 		}
 		/* load the monsters */
@@ -1785,7 +1760,7 @@ errr rd_server_savefile()
 		/* Incompatible save files */
 		if (tmp16u > MAX_O_IDX)
 		{
-			note(format("Too many (%u) objects!", tmp16u));
+			plog_fmt("Too many (%u) objects!", tmp16u);
 			return (26);
 		}
 
@@ -1815,7 +1790,7 @@ errr rd_server_savefile()
 			/* Verify monster index */
 			if (o_ptr->held_m_idx > z_info->m_max)
 			{
-				note("Invalid monster index");
+				plog("Invalid monster index");
 				return (-1);
 			}
 	
@@ -1836,7 +1811,7 @@ errr rd_server_savefile()
 		/* Incompatible save files */
 		if (tmp16u > MAX_HOUSES)
 		{
-			note(format("Too many (%u) houses!", tmp16u));
+			plog_fmt("Too many (%u) houses!", tmp16u);
 			return (27);
 		}
 
@@ -1855,7 +1830,7 @@ errr rd_server_savefile()
 				
 		if (tmp32u > MAX_WILD)
 		{
-			note("Too many wilderness levels");
+			plog("Too many wilderness levels");
 			return 28;
 		}
 	

--- a/src/server/load2.c
+++ b/src/server/load2.c
@@ -94,7 +94,7 @@ void start_section_read(char* name)
 	}
 	if(!matched)
 	{
-		plog(format("Missing section.  Expected '%s', found '%s' at line %i",seek_section,got_section,line_counter));
+		plog_fmt("Missing section.  Expected '%s', found '%s' at line %i",seek_section,got_section,line_counter);
 		exit(1);
 	}
 }
@@ -115,7 +115,7 @@ void end_section_read(char* name)
 	}
 	if(!matched)
 	{
-		plog(format("Missing end section.  Expected '%s', found '%s' at line %i",seek_section,got_section,line_counter));
+		plog_fmt("Missing end section.  Expected '%s', found '%s' at line %i",seek_section,got_section,line_counter);
 		exit(1);
 	}
 }
@@ -135,7 +135,7 @@ int read_int(char* name)
 	}
 	if(!matched)
 	{
-		plog(format("Missing integer.  Expected '%s', found '%s' at line %i",name,file_buf,line_counter));
+		plog_fmt("Missing integer.  Expected '%s', found '%s' at line %i",name,file_buf,line_counter);
 		exit(1);
 	}
 	return value;
@@ -156,7 +156,7 @@ uint read_uint(char* name)
 	}
 	if(!matched)
 	{		
-		plog(format("Missing unsigned integer.  Expected '%s', found '%s' at line %i",name,file_buf,line_counter));
+		plog_fmt("Missing unsigned integer.  Expected '%s', found '%s' at line %i",name,file_buf,line_counter);
 		exit(1);
 	}
 	return value;
@@ -177,7 +177,7 @@ huge read_huge(char* name)
 	}
 	if(!matched)
 	{		
-		plog(format("Missing signed long.  Expected '%s', found '%s' at line %i",name,file_buf,line_counter));
+		plog_fmt("Missing signed long.  Expected '%s', found '%s' at line %i",name,file_buf,line_counter);
 		exit(1);
 	}
 	return value;
@@ -197,7 +197,7 @@ void read_str(char* name, char* value)
 	sscanf(file_buf,"%s = ",seek_name);
 	if(strcmp(seek_name,name))
 	{
-		plog(format("Missing string data.  Expected '%s' got '%s' at line %i",name,seek_name,line_counter));
+		plog_fmt("Missing string data.  Expected '%s' got '%s' at line %i",name,seek_name,line_counter);
 		exit(1);
 	}
 
@@ -228,7 +228,7 @@ float read_float(char* name)
 	}
 	if(!matched)
 	{
-		plog(format("Missing float.  Expected '%s', found '%s' at line %i",name,file_buf,line_counter));
+		plog_fmt("Missing float.  Expected '%s', found '%s' at line %i",name,file_buf,line_counter);
 		exit(1);
 	}
 	return value;
@@ -250,7 +250,7 @@ void read_binary(char* name, char* value, int max_len)
 	sscanf(file_buf,"%s = ",seek_name);
 	if(strcmp(seek_name,name))
 	{
-		plog(format("Missing binary data.  Expected '%s' got '%s' at line %i",name,seek_name,line_counter));
+		plog_fmt("Missing binary data.  Expected '%s' got '%s' at line %i",name,seek_name,line_counter);
 		exit(1);
 	}
 
@@ -287,7 +287,7 @@ void skip_value(char* name)
 		/* Move back on seek failures */
 		fseek(file_handle,fpos,SEEK_SET);
 		line_counter--;
-		/* plog(format("Missing value.  Expected to skip '%s', found '%s' at line %i\n",name,seek_name,line_counter)); */
+		/* plog_fmt("Missing value.  Expected to skip '%s', found '%s' at line %i\n",name,seek_name,line_counter); */
 		/* exit(1); */
 		
 	}

--- a/src/server/netserver.c
+++ b/src/server/netserver.c
@@ -433,7 +433,7 @@ int Setup_net_server(void)
 	/* Tell the metaserver that we're starting up */
 	Report_to_meta(META_START);
 
-	plog(format("Server is running version %04x\n", MY_VERSION));
+	plog_fmt("Server is running version %04x\n", MY_VERSION);
 
 	return 0;
 }
@@ -545,7 +545,7 @@ static int Check_names(char *nick_name, char *real_name, char *host_name, char *
 		p_ptr = Players[i];
 		if (strcasecmp(p_ptr->name, nick_name) == 0)
 		{
-			/*plog(format("%s %s", Players[i]->name, nick_name));*/
+			/*plog_fmt("%s %s", Players[i]->name, nick_name);*/
 
 			/* The following code allows you to "override" an
 			 * existing connection by connecting again  -Crimson */
@@ -674,7 +674,7 @@ static void Contact(int fd, int arg)
 			/* We couldn't accept the socket connection. This is bad because we can't
 			 * handle this situation correctly yet.  For the moment, we just log the
 			 * error and quit */
-			plog(format("Could not accept TCP Connection, socket error = %d",errno));
+			plog_fmt("Could not accept TCP Connection, socket error = %d",errno);
 			quit("Couldn't accept TCP connection.");
 		}
 		install_input(Contact, newsock, 2);
@@ -717,13 +717,13 @@ static void Contact(int fd, int arg)
 
 	if (Packet_scanf(&ibuf, "%u", &magic) <= 0)
 	{
-		plog(format("Incompatible packet from %s", host_addr));
+		plog_fmt("Incompatible packet from %s", host_addr);
 		return;
 	}
 
 	if (Packet_scanf(&ibuf, "%s%hu%c", real_name, &port, &ch) <= 0)
 	{
-		plog(format("Incomplete packet from %s", host_addr));
+		plog_fmt("Incomplete packet from %s", host_addr);
 		return;
 	}
 	reply_to = (ch & 0xFF);
@@ -732,7 +732,7 @@ static void Contact(int fd, int arg)
 
 	if (Packet_scanf(&ibuf, "%s%s%hu", nick_name, host_name, &version) <= 0)
 	{
-		plog(format("Incomplete login from %s", host_addr));
+		plog_fmt("Incomplete login from %s", host_addr);
 		return;
 	}
 	nick_name[sizeof(nick_name) - 1] = '\0';
@@ -923,7 +923,7 @@ bool Destroy_connection(int ind, char *reason)
 	if (connp->state == CONN_FREE)
 	{
 		errno = 0;
-		plog(format("Cannot destroy empty connection (\"%s\")", reason));
+		plog_fmt("Cannot destroy empty connection (\"%s\")", reason);
 		return TRUE;
 	}
 
@@ -948,11 +948,11 @@ bool Destroy_connection(int ind, char *reason)
 			DgramWrite(sock, pkt, len);
 		}
 	}
-	plog(format("Goodbye %s=%s@%s (\"%s\")",
+	plog_fmt("Goodbye %s=%s@%s (\"%s\")",
 		connp->nick ? connp->nick : "",
 		connp->real ? connp->real : "",
 		connp->host ? connp->host : "",
-		reason));
+		reason);
 
 	Conn_set_state(connp, CONN_FREE, CONN_FREE);
 
@@ -1042,7 +1042,7 @@ int Setup_connection(char *real, char *nick, char *addr, char *host,
 
 	if (free_conn_index >= max_connections)
 	{
-		plog(format("Full house for %s(%s)@%s", real, nick, host));
+		plog_fmt("Full house for %s(%s)@%s", real, nick, host);
 		return -1;
 	}
 	connp = &Conn[free_conn_index];
@@ -1069,9 +1069,9 @@ int Setup_connection(char *real, char *nick, char *addr, char *host,
 		plog("Couldn't set SO_LINGER on the socket");
 	}
 	if (SetSocketReceiveBufferSize(sock, SERVER_RECV_SIZE + 256) == -1)
-		plog(format("Cannot set receive buffer size to %d", SERVER_RECV_SIZE + 256));
+		plog_fmt("Cannot set receive buffer size to %d", SERVER_RECV_SIZE + 256);
 	if (SetSocketSendBufferSize(sock, SERVER_SEND_SIZE + 256) == -1)
-		plog(format("Cannot set send buffer size to %d", SERVER_SEND_SIZE + 256));
+		plog_fmt("Cannot set send buffer size to %d", SERVER_SEND_SIZE + 256);
 
 	Sockbuf_init(&connp->w, sock, SERVER_SEND_SIZE, SOCKBUF_WRITE);
 	Sockbuf_init(&connp->r, sock, SERVER_RECV_SIZE, SOCKBUF_WRITE | SOCKBUF_READ);
@@ -1414,13 +1414,13 @@ static int Handle_listening(int ind)
 	}
 	
 	/* Log the players connection */
-	plog(format("Welcome %s=%s@%s (%s/%d) (version %04x)", connp->nick,
-		connp->real, connp->host, connp->addr, connp->his_port,connp->version));
+	plog_fmt("Welcome %s=%s@%s (%s/%d) (version %04x)", connp->nick,
+		connp->real, connp->host, connp->addr, connp->his_port,connp->version);
 
 	if (strcmp(real, connp->real))
 	{
-		plog(format("Client verified incorrectly (%s, %s)(%s, %s)",
-			real, nick, connp->real, connp->nick));
+		plog_fmt("Client verified incorrectly (%s, %s)(%s, %s)",
+			real, nick, connp->real, connp->nick);
 		Send_reply(ind, PKT_VERIFY, PKT_FAILURE);
 		Send_reliable(ind);
 		Destroy_connection(ind, "verify incorrect");
@@ -1511,7 +1511,7 @@ static int Handle_login(int ind)
 	if (Id >= MAX_ID)
 	{
 		errno = 0;
-		plog(format("Id too big (%d)", Id));
+		plog_fmt("Id too big (%d)", Id);
 		return -2;
 	}
 
@@ -1520,7 +1520,7 @@ static int Handle_login(int ind)
 		if (strcasecmp(Players[i]->name, connp->nick) == 0)
 		{
 			errno = 0;
-			plog(format("Name already in use %s", connp->nick));
+			plog_fmt("Name already in use %s", connp->nick);
 			Destroy_connection(ind, "not login"); 
 			return -1;
 		}
@@ -2089,8 +2089,8 @@ int Send_leave(int ind, int id)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for leave info (%d,%d)",
-			connp->state, connp->id));
+		plog_fmt("Connection not ready for leave info (%d,%d)",
+			connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hd", PKT_LEAVE, id);
@@ -2185,7 +2185,7 @@ static int Receive_play(int ind)
 	if (ch != PKT_PLAY)
 	{
 		errno = 0;
-		plog(format("Packet is not of play type - (%02x)", ch));
+		plog_fmt("Packet is not of play type - (%02x)", ch);
 		Destroy_connection(ind, format("not play - (%02x)", ch));
 		return -1;
 	}
@@ -2199,7 +2199,7 @@ static int Receive_play(int ind)
 				return 0;
 			}
 			errno = 0;
-			plog(format("Connection not in login state (%02x)", connp->state));
+			plog_fmt("Connection not in login state (%02x)", connp->state);
 			Destroy_connection(ind, "not login");
 			return -1;
 		}
@@ -2213,7 +2213,7 @@ static int Receive_play(int ind)
 	if ((n = Handle_login(ind)) == -2)
 	{
 		errno = 0;
-		plog(format("Could not login player (%02x)", connp->state));
+		plog_fmt("Could not login player (%02x)", connp->state);
 		Destroy_connection(ind, "cant handle");
 	}
 	if (n < 0)
@@ -2243,7 +2243,7 @@ int Send_reliable(int ind)
 	}
 	if ((num_written = Sockbuf_flush(&connp->w)) < 0)
 	{
-		plog(format("Cannot flush reliable data (%d)", num_written));
+		plog_fmt("Cannot flush reliable data (%d)", num_written);
 		Destroy_connection(ind, "flush error");
 		return -1;
 	}
@@ -2263,14 +2263,14 @@ static int Receive_ack(int ind)
 		<= 0)
 	{
 		errno = 0;
-		plog(format("Cannot read ack packet (%d)", n));
+		plog_fmt("Cannot read ack packet (%d)", n);
 		Destroy_connection(ind, "read error");
 		return -1;
 	}
 	if (ch != PKT_ACK)
 	{
 		errno = 0;
-		plog(format("Not an ack packet (%d)", ch));
+		plog_fmt("Not an ack packet (%d)", ch);
 		Destroy_connection(ind, "not ack");
 		return -1;
 	}
@@ -2293,8 +2293,8 @@ static int Receive_ack(int ind)
 	if (diff > connp->c.len)
 	{
 		errno = 0;
-		plog(format("Bad ack (ind=%d,diff=%ld,cru=%ld)",
-			ind,diff, rel ));
+		plog_fmt("Bad ack (ind=%d,diff=%ld,cru=%ld)",
+			ind,diff, rel );
 		Destroy_connection(ind, "bad ack");
 		return -1;
 	}
@@ -2332,8 +2332,8 @@ static int Receive_discard(int ind)
 	connection_t *connp = &Conn[ind];
 
 	errno = 0;
-	plog(format("Discarding packet %d while in state %02x",
-		connp->r.ptr[0], connp->state));
+	plog_fmt("Discarding packet %d while in state %02x",
+		connp->r.ptr[0], connp->state);
 	connp->r.ptr = connp->r.buf + connp->r.len;
 
 	return 0;
@@ -2344,7 +2344,7 @@ static int Receive_undefined(int ind)
 	connection_t *connp = &Conn[ind];
 
 	errno = 0;
-	plog(format("Unknown packet type %s (%d,%02x)",connp->nick, connp->r.ptr[0], connp->state));
+	plog_fmt("Unknown packet type %s (%d,%02x)",connp->nick, connp->r.ptr[0], connp->state);
 	Destroy_connection(ind, "undefined packet"); 
 	return -1;
 }
@@ -2356,8 +2356,8 @@ int Send_plusses(int ind, int tohit, int todam)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for plusses (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for plusses (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hd%hd", PKT_PLUSSES, tohit, todam);
@@ -2371,8 +2371,8 @@ int Send_ac(int ind, int base, int plus)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for ac (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for ac (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hd%hd", PKT_AC, base, plus);
@@ -2385,8 +2385,8 @@ int Send_experience(int ind, int lev, int max, int cur, s32b adv)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for experience (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for experience (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hu%d%d%d", PKT_EXPERIENCE, lev, 
@@ -2400,8 +2400,8 @@ int Send_gold(int ind, s32b au)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for gold (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for gold (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%d", PKT_GOLD, au);
@@ -2414,8 +2414,8 @@ int Send_hp(int ind, int mhp, int chp)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for hp (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for hp (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -2429,8 +2429,8 @@ int Send_sp(int ind, int msp, int csp)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for sp (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for sp (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hd%hd", PKT_SP, msp, csp);
@@ -2443,8 +2443,8 @@ int Send_char_info(int ind, int race, int class, int sex)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for char info (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for char info (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hd%hd%hd", PKT_CHAR_INFO, race, class, sex);
@@ -2457,8 +2457,8 @@ int Send_various(int ind, int hgt, int wgt, int age, int sc)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for various (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for various (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hu%hu%hu%hu", PKT_VARIOUS, hgt, wgt, age, sc);
@@ -2471,8 +2471,8 @@ int Send_stat(int ind, int stat, int max, int cur)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for stat (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for stat (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -2486,8 +2486,8 @@ int Send_maxstat(int ind, int stat, int max)
     if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
     {
         errno = 0;
-        plog(format("Connection not ready for maxstat (%d.%d.%d)",
-            ind, connp->state, connp->id));
+        plog_fmt("Connection not ready for maxstat (%d.%d.%d)",
+            ind, connp->state, connp->id);
         return 0;
     }
 
@@ -2505,8 +2505,8 @@ int Send_objflags(int Ind, int line)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for objflags (%d.%d.%d)",
-			Ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for objflags (%d.%d.%d)",
+			Ind, connp->state, connp->id);
 		return 0;
 	}
 	
@@ -2570,8 +2570,8 @@ int Send_history(int ind, int line, cptr hist)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for history (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for history (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hu%s", PKT_HISTORY, line, hist);
@@ -2584,8 +2584,8 @@ int Send_inven(int ind, char pos, byte attr, int wgt, int amt, byte tval, cptr n
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for inven (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for inven (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%c%c%hu%hd%c%s", PKT_INVEN, pos, attr, wgt, amt, tval, name);
@@ -2598,8 +2598,8 @@ int Send_equip(int ind, char pos, byte attr, int wgt, byte tval, cptr name)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for equip (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for equip (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%c%c%hu%c%s", PKT_EQUIP, pos, attr, wgt, tval, name);
@@ -2612,8 +2612,8 @@ int Send_title(int ind, cptr title)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for title (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for title (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%s", PKT_TITLE, title);
@@ -2626,8 +2626,8 @@ int Send_depth(int ind, int depth)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for depth (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for depth (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hu", PKT_DEPTH, depth);
@@ -2640,8 +2640,8 @@ int Send_food(int ind, int food)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for food (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for food (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hu", PKT_FOOD, food);
@@ -2654,8 +2654,8 @@ int Send_blind(int ind, bool blind)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for blind (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for blind (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%c", PKT_BLIND, blind);
@@ -2668,8 +2668,8 @@ int Send_confused(int ind, bool confused)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for confusion (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for confusion (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%c", PKT_CONFUSED, confused);
@@ -2682,8 +2682,8 @@ int Send_fear(int ind, bool fear)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for fear (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for fear (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%c", PKT_FEAR, fear);
@@ -2696,8 +2696,8 @@ int Send_poison(int ind, bool poisoned)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for poison (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for poison (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%c", PKT_POISON, poisoned);
@@ -2710,8 +2710,8 @@ int Send_state(int ind, bool paralyzed, bool searching, bool resting)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for state (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for state (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hu%hu%hu", PKT_STATE, paralyzed, searching, resting);
@@ -2724,8 +2724,8 @@ int Send_speed(int ind, int speed)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for speed (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for speed (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hd", PKT_SPEED, speed);
@@ -2738,8 +2738,8 @@ int Send_study(int ind, bool study)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for study (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for study (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%c", PKT_STUDY, study);
@@ -2752,8 +2752,8 @@ int Send_cut(int ind, int cut)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for cut (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for cut (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hu", PKT_CUT, cut);
@@ -2766,8 +2766,8 @@ int Send_stun(int ind, int stun)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for stun (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for stun (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hu", PKT_STUN, stun);
@@ -2780,8 +2780,8 @@ int Send_direction(int ind)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for direction (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for direction (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c", PKT_DIRECTION);
@@ -2798,8 +2798,8 @@ int Send_message(int ind, cptr msg)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for message (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for message (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -2825,8 +2825,8 @@ int Send_spell_info(int ind, int book, int i, cptr out_val)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for spell info (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for spell info (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c%hu%hu%s", PKT_SPELL_INFO, book, i, out_val);
@@ -2840,8 +2840,8 @@ int Send_item_request(int ind)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for item request (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for item request (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c", PKT_ITEM);
@@ -2854,8 +2854,8 @@ int Send_flush(int ind)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for flush (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for flush (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	return Packet_printf(&connp->c, "%c", PKT_FLUSH);
@@ -2878,8 +2878,8 @@ int Send_line_info(int ind, int y)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for line info (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for line info (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	
@@ -2944,8 +2944,8 @@ int Send_mini_map(int ind, int y)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for minimap (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for minimap (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 	    
@@ -3006,8 +3006,8 @@ int Send_store(int ind, char pos, byte attr, int wgt, int number, int price, cpt
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for store item (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for store item (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3023,8 +3023,8 @@ int Send_store_info(int ind, int num, int owner, int items)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for store info (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for store info (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3040,8 +3040,8 @@ int Send_player_store_info(int ind, int num, char *owner, int items)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for store info (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for store info (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3055,8 +3055,8 @@ int Send_store_sell(int ind, int price)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for sell price (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for sell price (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3071,8 +3071,8 @@ int Send_target_info(int ind, int x, int y, cptr str)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for target info (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for target info (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3092,8 +3092,8 @@ int Send_sound(int ind, int sound)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for sound (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for sound (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3108,8 +3108,8 @@ int Send_special_line(int ind, int max, int line, byte attr, cptr buf)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for special line (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for special line (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3125,8 +3125,8 @@ int Send_floor(int ind, char tval)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for floor item (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for floor item (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3140,8 +3140,8 @@ int Send_pickup_check(int ind, cptr buf)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for pickup check (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for pickup check (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3162,8 +3162,8 @@ int Send_party(int ind)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection nor ready for party info (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection nor ready for party info (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3189,8 +3189,8 @@ int Send_special_other(int ind, char *header)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for special other (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for special other (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3233,8 +3233,8 @@ int Send_skills(int ind)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for skills (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for skills (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3256,8 +3256,8 @@ int Send_pause(int ind)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for skills (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for skills (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3272,8 +3272,8 @@ int Send_cursor(int ind, char vis, char x, char y)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for cursor position (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for cursor position (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 
@@ -3288,8 +3288,8 @@ int Send_monster_health(int ind, int num, byte attr)
 	if (!BIT(connp->state, CONN_PLAYING | CONN_READY))
 	{
 		errno = 0;
-		plog(format("Connection not ready for monster health bar (%d.%d.%d)",
-			ind, connp->state, connp->id));
+		plog_fmt("Connection not ready for monster health bar (%d.%d.%d)",
+			ind, connp->state, connp->id);
 		return 0;
 	}
 

--- a/src/server/object2.c
+++ b/src/server/object2.c
@@ -213,7 +213,7 @@ void delete_object(int Depth, int y, int x)
     /* Paranoia -- make sure the level has been allocated */ 
     if (!cave[Depth]) 
     { 
-        plog(format("Error : tried to delete object on unallocated level %d",Depth));
+        plog_fmt("Error : tried to delete object on unallocated level %d",Depth);
         return; 
     } 
 
@@ -1609,7 +1609,7 @@ s16b lookup_kind(int tval, int sval)
 	}
 
 	/* Oops */
-	plog(format("No object (%d,%d)", tval, sval));
+	plog_fmt("No object (%d,%d)", tval, sval);
 
 	/* Oops */
 	return (0);
@@ -1867,7 +1867,7 @@ static bool make_artifact_special(int Depth, object_type *o_ptr)
 		/* Mega-Hack -- mark the item as an artifact */
 		o_ptr->name1 = i;
 		object_desc(0, o_name, o_ptr, TRUE, 3);
-        plog(format("Special artifact %s created", o_name));
+        plog_fmt("Special artifact %s created", o_name);
 
 
 		/* Success */
@@ -1947,7 +1947,7 @@ static bool make_artifact(int Depth, object_type *o_ptr)
 		/* Hack -- mark the item as an artifact */
 		o_ptr->name1 = i;
         object_desc(0, o_name, o_ptr, TRUE, 3);
-        plog(format("Artifact %s created", o_name));
+        plog_fmt("Artifact %s created", o_name);
 
 		/* Success */
 		return (TRUE);

--- a/src/server/save.c
+++ b/src/server/save.c
@@ -1038,7 +1038,7 @@ bool load_player(int Ind)
 	if (access(p_ptr->savefile, 0) < 0)
 	{
 		/* Give a message */
-		plog(format("Savefile does not exist for player %s", p_ptr->name));
+		plog_fmt("Savefile does not exist for player %s", p_ptr->name);
 
 		/* Allow this */
 		return (TRUE);
@@ -1510,7 +1510,7 @@ bool load_server_info(void)
         }
 
 	/* Message */
-	plog(format("Error (%s,%d) reading server savefile.", what, err));
+	plog_fmt("Error (%s,%d) reading server savefile.", what, err);
 
 	return (FALSE);
 }

--- a/src/server/sched-win.c
+++ b/src/server/sched-win.c
@@ -31,7 +31,7 @@
 #include <winsock2.h>
 #include "angband.h"   
 #include <mmsystem.h>
-#include <winbase.h> 
+#include <winbase.h> 
 
 static volatile long timer_ticks;  
 static long frame_count;  
@@ -80,7 +80,7 @@ static void setup_timer(void)
    */
   delay = 1000/timer_freq;
   delay = delay/resolution;
-  plog(format("Timer delay %i ms timer resolution is %i ms\n",delay,resolution));
+  plog_fmt("Timer delay %i ms timer resolution is %i ms\n",delay,resolution);
   if(!timeBeginPeriod(resolution) == TIMERR_NOERROR)
   {
 	plog("Could not set the timer to the required resolution");
@@ -256,11 +256,11 @@ void install_input(void (*func)(int, int), int fd, int arg)
     input_mask_cleared = TRUE;
   }
   if (fd < 0 ) {
-    plog(format("install illegal input handler fd %d", fd));
+    plog_fmt("install illegal input handler fd %d", fd);
     exit(1);
   }
   if (FD_ISSET(fd,&input_mask)) {
-    plog(format("input handler %d busy", fd));
+    plog_fmt("input handler %d busy", fd);
     exit(1);
   }
   if(input_handlers == NULL || fd > biggest_fd)
@@ -273,7 +273,7 @@ void install_input(void (*func)(int, int), int fd, int arg)
     }
     if( input_handlers == NULL )
     {
-      plog(format("input handler %d realloc failed", fd));
+      plog_fmt("input handler %d realloc failed", fd);
       exit(1);
     }
   }
@@ -288,7 +288,7 @@ void install_input(void (*func)(int, int), int fd, int arg)
 void remove_input(int fd)
 {
   if ( fd < 0 ) {
-    plog(format("remove illegal input handler fd %d", fd));
+    plog_fmt("remove illegal input handler fd %d", fd);
     exit(1);
   }
   if (FD_ISSET( fd, &input_mask )) {
@@ -367,7 +367,7 @@ void sched(void)
       n = select(max_fd, &readmask, NULL, NULL, &tv);
       if (n < 0) {
         if (errno != EINTR) {
-          plog(format("Errno: %d\n",errno));
+          plog_fmt("Errno: %d\n",errno);
           core("sched select error");
           exit(1);
         }

--- a/src/server/sched.c
+++ b/src/server/sched.c
@@ -89,7 +89,7 @@ static void sig_ok(int signum, int flag)
     sigemptyset(&sigset);
     sigaddset(&sigset, signum);
     if (sigprocmask((flag) ? SIG_UNBLOCK : SIG_BLOCK, &sigset, NULL) == -1) {
-	plog(format("sigprocmask(%d,%d)", signum, flag));
+	plog_fmt("sigprocmask(%d,%d)", signum, flag);
 	exit(1);
     }
 }
@@ -157,7 +157,7 @@ static void setup_timer(void)
      * Install a real-time timer.
      */
     if (timer_freq <= 0) {
-	plog(format("illegal timer frequency: %ld", timer_freq));
+	plog_fmt("illegal timer frequency: %ld", timer_freq);
 	exit(1);
     }
     itv.it_interval.tv_sec = 0;
@@ -336,11 +336,11 @@ void install_input(void (*func)(int, int), int fd, int arg)
        input_mask_cleared = TRUE;
     }
     if (fd < 0 ) {
-	plog(format("install illegal input handler fd %d", fd));
+	plog_fmt("install illegal input handler fd %d", fd);
 	exit(1);
     }
     if (FD_ISSET(fd,&input_mask)) {
-	plog(format("input handler %d busy", fd));
+	plog_fmt("input handler %d busy", fd);
 	exit(1);
     }
     if(input_handlers == NULL || fd > biggest_fd)
@@ -353,7 +353,7 @@ void install_input(void (*func)(int, int), int fd, int arg)
         }
         if( input_handlers == NULL )
         {
-           plog(format("input handler %d realloc failed", fd));
+           plog_fmt("input handler %d realloc failed", fd);
            exit(1);
         }
     }
@@ -368,7 +368,7 @@ void install_input(void (*func)(int, int), int fd, int arg)
 void remove_input(int fd)
 {
     if ( fd < 0 ) {
-	plog(format("remove illegal input handler fd %d", fd));
+	plog_fmt("remove illegal input handler fd %d", fd);
 	exit(1);
     }
     if (FD_ISSET( fd, &input_mask )) {
@@ -468,7 +468,7 @@ void sched(void)
 	    n = select(max_fd, &readmask, 0, 0, tvp);
 	    if (n < 0) {
 		if (errno != EINTR) {
-                    plog(format("Errno: %d\n",errno));
+                    plog_fmt("Errno: %d\n",errno);
 		    core("sched select error");
 		    exit(1);
 		}

--- a/src/server/util.c
+++ b/src/server/util.c
@@ -2509,11 +2509,11 @@ void msg_print(int Ind, cptr msg)
 		/* Maintain a circular buffer */
 		if(p_ptr->msg_hist_ptr == MAX_MSG_HIST) 
 			p_ptr->msg_hist_ptr = 0;
-		plog(format("%s: %s",Players[Ind]->name,msg)); 
+		plog_fmt("%s: %s",Players[Ind]->name,msg);
 	}
 	else if(msg && log)
 	{
-		plog(format("%d: %s",Ind,msg)); 
+		plog_fmt("%d: %s",Ind,msg);
 	}; 	
 
 	/* Ahh, the beautiful simplicity of it.... --KLJ-- */


### PR DESCRIPTION
There are already functions plog_fmt and quit_fmt. They still use the same static buffer owned by vformat, but it removes a step & makes the PR easier. There are some whitespace changes here. In all cases, the file was tending heavily towards DOS format, so I made the decision to fix it and encode properly as DOS.