### PR TITLE
Close #1195, refactor and fix house pricing.

### DIFF
--- a/src/common/types.h
+++ b/src/common/types.h
@@ -280,7 +280,7 @@ struct house_type
 
 	s32b depth;
 
-	s32b price;             	/* Cost of buying */
+	u32b price;             	/* Cost of buying */
 };
 
 

--- a/src/server/externs.h
+++ b/src/server/externs.h
@@ -603,6 +603,8 @@ extern void generate_cave(int Ind, int Depth,int auto_scum);
 extern void build_vault(int Depth, int yval, int xval, int ymax, int xmax, cptr data);
 
 /* wilderness.c */
+extern u32b base_house_price(int h_idx);
+extern u32b house_price(int Ind, int h_idx, bool buying);
 extern int world_index(int world_x, int world_y);
 extern void wild_cat_depth(int Depth, char *buf); 
 extern void init_wild_info(void);

--- a/src/server/load2.c
+++ b/src/server/load2.c
@@ -942,7 +942,7 @@ static void rd_house(int n)
 	read_str("owned",house_ptr->owned); 
 
 	house_ptr->depth = read_int("depth");
-	house_ptr->price = read_int("price");
+	house_ptr->price = read_uint("price");
 
 	end_section_read("house");
 

--- a/src/server/save.c
+++ b/src/server/save.c
@@ -370,7 +370,7 @@ static void wr_house(house_type *house)
 	write_str("owned",house->owned);
 
 	write_int("depth",house->depth);
-	write_int("price",house->price);
+	write_uint("price",house->price);
 	end_section("house");
 }
 


### PR DESCRIPTION
OK, this was pretty hard to test, due to base house price being randomly assigned during town/wilderness generation.

So if you're going to test it, make sure to edit the server savefile and set same base price on both versions.

From my tests:
```
1.4.0
base price from 6x6 house in town     = 23760 gold
buying that house with CHR 16         = 121775 gold
selling that house with CHR 16        = 12177 gold

1.5.0+this changest:
base price for 4x3 house in town      = 21840 gold
manually edited save file to set base = 23760 gold
buying that house with CHR 16         = 121175 gold (YAY!)
selling that house with CHR 16        = 11761 gold
```

Note, that selling price was calculated wrongly on 1.4.0, so the only value I can directly compare is buying price, which I made sure is the same.

Also note, that the algorithm is pretty unfair in 1.4.0 -- when you buy a house in town, its price is multiplied x5, but when you sell it, same adjustment is *NOT* performed. Despite this "unfairness", I've kept it, to match 1.4.0 as closely as possible.

In other news, I see horrible unsigned long -> s32b conversions, which I also kept. But we shall handle this one day.