### PR TITLE
Add ability to cancel macros mid-command.

### DIFF
--- a/src/client/c-cmd.c
+++ b/src/client/c-cmd.c
@@ -33,6 +33,7 @@ void cmd_custom(byte i)
 		if (p_ptr->ghost)
 		{
 			if (!STRZERO(prompt)) c_msg_print(prompt);
+			command_aborted = TRUE;
 			return;
 		}
 		advance_prompt();
@@ -42,6 +43,7 @@ void cmd_custom(byte i)
 		if (!p_ptr->ghost)
 		{
 			if (!STRZERO(prompt)) c_msg_print(prompt);
+			command_aborted = TRUE;
 			return;
 		}
 		advance_prompt();
@@ -51,6 +53,7 @@ void cmd_custom(byte i)
 		if (c_info[pclass].spell_book != cc_ptr->tval)
 		{
 			if (!STRZERO(prompt)) c_msg_print(prompt);
+			command_aborted = TRUE;
 			return;
 		}
 		advance_prompt();
@@ -76,6 +79,7 @@ void cmd_custom(byte i)
 		if (!c_check_item(&item, cc_ptr->tval))
 		{
 			if (!STRZERO(prompt)) c_msg_print(prompt);
+			command_aborted = TRUE;
 			return;
 		}
 		advance_prompt();
@@ -83,7 +87,11 @@ void cmd_custom(byte i)
 	/* Ask for a store item (interactive) ? */
 	else if (cc_ptr->flag & COMMAND_ITEM_STORE)
 	{
-		if (!get_store_stock(&item, prompt)) return;
+		if (!get_store_stock(&item, prompt))
+		{
+			command_aborted = TRUE;
+			return;
+		}
 		advance_prompt();
 
 		/* Get an amount */
@@ -102,7 +110,11 @@ void cmd_custom(byte i)
 				value = c_get_quantity(prompt, store.stock[item].number);
 				shopping_buying = FALSE;
 			}
-			if (!value) return;
+			if (!value)
+			{
+				command_aborted = TRUE;
+				return;
+			}
 			advance_prompt();
         }
 
@@ -118,7 +130,10 @@ void cmd_custom(byte i)
 				(cc_ptr->flag & COMMAND_ITEM_EQUIP ? TRUE : FALSE),
 				(cc_ptr->flag & COMMAND_ITEM_INVEN ? TRUE : FALSE),
 				(cc_ptr->flag & COMMAND_ITEM_FLOOR ? TRUE : FALSE)))
+		{
+				command_aborted = TRUE;
 				return;
+		}
 		second_item_tester = c_secondary_tester(item);
 		advance_prompt();
 
@@ -138,7 +153,11 @@ void cmd_custom(byte i)
 				if (STRZERO(prompt)) prompt = "How many? ";
 				value = c_get_quantity(prompt, floor_item.number);
 			}
-			if (!value) return;
+			if (!value)
+			{
+				command_aborted = TRUE;
+				return;
+			}
 			advance_prompt();
 		}
 
@@ -157,7 +176,7 @@ void cmd_custom(byte i)
 				need_target = (floor_item.ident & ITEM_ASK_AIM  ? TRUE : FALSE);
 				need_second = (floor_item.ident & ITEM_ASK_ITEM ? TRUE : FALSE);
 			}
-		}		
+		}
 	}
 	/* Spell? */
 	if (cc_ptr->flag & COMMAND_NEED_SPELL)
@@ -167,13 +186,21 @@ void cmd_custom(byte i)
 		advance_prompt();
 		if (cc_ptr->flag & COMMAND_SPELL_BOOK)
 		{
-			if (!get_spell(&spell, p, prompt, &item, FALSE)) return;
+			if (!get_spell(&spell, p, prompt, &item, FALSE))
+			{
+				command_aborted = TRUE;
+				return;
+			}
 			index = item * SPELLS_PER_BOOK + spell;
 		}
 		else
 		{
 			int book = cc_ptr->tval;
-			if (!get_spell(&spell, p, prompt, &book, FALSE)) return;
+			if (!get_spell(&spell, p, prompt, &book, FALSE))
+			{
+				command_aborted = TRUE;
+				return;
+			}
 			index = book * SPELLS_PER_BOOK + spell;
 			indoff = cc_ptr->tval * SPELLS_PER_BOOK;
 		}
@@ -210,7 +237,10 @@ void cmd_custom(byte i)
 				(cc_ptr->flag & COMMAND_SECOND_EQUIP ? TRUE : FALSE),
 				(cc_ptr->flag & COMMAND_SECOND_INVEN ? TRUE : FALSE),
 				(cc_ptr->flag & COMMAND_SECOND_FLOOR ? TRUE : FALSE)))
+		{
+				command_aborted = TRUE;
 				return;
+		}
 		advance_prompt();
 	}
 	/* Target? */
@@ -219,7 +249,10 @@ void cmd_custom(byte i)
 		if (!c_get_dir(&dir, prompt,
 				(cc_ptr->flag & COMMAND_TARGET_ALLOW ? TRUE : FALSE),
 				(cc_ptr->flag & COMMAND_TARGET_FRIEND ? TRUE : FALSE)))
+		{
+				command_aborted = TRUE;
 				return;
+		}
 		advance_prompt();
 	}
 	/* Auto-modify prompt? */
@@ -232,14 +265,21 @@ void cmd_custom(byte i)
 	{
 		if (STRZERO(prompt)) prompt = "Quantity: ";
 		value = c_get_quantity(prompt, 999000000);
-		if (!value) return;
+		if (!value)
+		{
+			command_aborted = TRUE;
+			return;
+		}
 		advance_prompt();
 	}
 	if (cc_ptr->flag & COMMAND_NEED_CHAR)
 	{
 		if (STRZERO(prompt)) prompt = "Command: ";
-		if (!get_com(prompt, &entry[0])) 
+		if (!get_com(prompt, &entry[0]))
+		{
+			command_aborted = TRUE;
 			return;
+		}
 		entry[1] = '\0';
 		advance_prompt();
 	}
@@ -247,14 +287,20 @@ void cmd_custom(byte i)
 	{
 		if (STRZERO(prompt)) prompt = "Entry: ";
 		if (!get_string(prompt, entry, sizeof(entry) - 1))
+		{
+			command_aborted = TRUE;
 			return;
+		}
 		advance_prompt();
 	}
 	if (cc_ptr->flag & COMMAND_NEED_CONFIRM)
 	{
 		if (STRZERO(prompt)) prompt = "Really perform said action ? ";
 		if (!get_check(prompt))
+		{
+			command_aborted = TRUE;
 			return;
+		}
 		advance_prompt();
 	}
 	/* Post-effects */
@@ -281,6 +327,7 @@ void cmd_custom(byte i)
 void process_command()
 {
 	byte i;
+	command_aborted = FALSE;
 	for (i = 0; i < custom_commands; i++) 
 	{
 		if (custom_command[i].flag & COMMAND_STORE) continue;
@@ -800,6 +847,7 @@ void cmd_describe(void)
 
 	if (!c_get_item(&item, "Describe what? ", TRUE, TRUE, TRUE))
 	{
+		command_aborted = TRUE;
 		return;
 	}
 
@@ -1308,6 +1356,7 @@ void cmd_browse(void)
 	if (!c_info[pclass].spell_book)
 	{
 		c_msg_print("You cannot read books!");
+		command_aborted = TRUE;
 		return;
 	}
 
@@ -1316,6 +1365,7 @@ void cmd_browse(void)
 	if (!c_get_item(&item, "Browse which book? ", FALSE, TRUE, FALSE))
 	{
 		if (item == -2) c_msg_print("You have no books that you can read.");
+		command_aborted = TRUE;
 		return;
 	}
 

--- a/src/client/c-externs.h
+++ b/src/client/c-externs.h
@@ -214,6 +214,7 @@ extern cptr keymap_act[KEYMAP_MODES][256];
 extern s16b command_cmd;
 extern s16b command_dir;
 extern event_type command_cmd_ex;
+extern bool command_aborted;
 
 extern custom_command_type custom_command[MAX_CUSTOM_COMMANDS];
 extern int custom_commands;

--- a/src/client/c-util.c
+++ b/src/client/c-util.c
@@ -300,6 +300,11 @@ static event_type inkey_aux(void)
 		}
 	} while (!ch);
 
+	/* Hack -- if "command_aborted" is TRUE, ignore all keystrokes,
+	 * till we reach the "end of macro". "End of macro" is either
+	 * char 30, either a 0. */
+	if (command_aborted && parse_macro) return ke0;
+
 	
 	/* ARCANE MAGIC STARTS BELOW: */
 
@@ -312,6 +317,7 @@ static event_type inkey_aux(void)
 	/* End "macro action" */
 	if ((ch == 30) || (ch == '\xff'))
 	{
+		command_aborted = FALSE;
 		parse_macro = FALSE;
 		return (ke);
 	}
@@ -770,6 +776,9 @@ event_type inkey_ex(void)
 		
 			/* End "macro trigger" */
 			parse_under = FALSE;
+
+			/* Macro has ended, stop ignoring commands */
+			command_aborted = FALSE;
 
 			/* Stop stripping */
 			strip_chars = FALSE;

--- a/src/client/c-variable.c
+++ b/src/client/c-variable.c
@@ -159,6 +159,7 @@ cptr keymap_act[KEYMAP_MODES][256]; /* Keymaps for each "mode" associated with e
 s16b command_cmd;
 s16b command_dir;
 event_type command_cmd_ex; /* Gives additional information of current command */
+bool command_aborted = FALSE; /* Hack -- set to TRUE to ignore the "rest of macro" */
 
 custom_command_type custom_command[MAX_CUSTOM_COMMANDS];
 int custom_commands;

--- a/src/client/z-term.c
+++ b/src/client/z-term.c
@@ -1974,6 +1974,9 @@ errr Term_flush(void)
 	/* Forget all keypresses */
 	Term->key_head = Term->key_tail = 0;
 
+	/* Hack -- we can no longer reliably tell */
+	command_aborted = FALSE;
+
 	/* Success */
 	return (0);
 }


### PR DESCRIPTION
**THIS PR IS A BIT MISGUIDED** See #1352 for the actual problem.

<s>Imagine a macro `\ef1*t`. If the `f` part fails ("You have no missile launcher."), the `1*t` part *still* gets executed, and `1` moves the player south-west.

There are many similar cases, when the command gets aborted, yet the macro continues execution.

It would be nice if we could tell, when the command has been aborted, and ignore the "rest of the macro", until we enter a new command.</s>