### PR TITLE
Address #776, add simple framework for macro overloading.

### DIFF
--- a/src/client/c-cmd.c
+++ b/src/client/c-cmd.c
@@ -281,6 +281,7 @@ void cmd_custom(byte i)
 void process_command()
 {
 	byte i;
+	command_aborted = FALSE;
 	for (i = 0; i < custom_commands; i++) 
 	{
 		if (custom_command[i].flag & COMMAND_STORE) continue;

--- a/src/client/c-externs.h
+++ b/src/client/c-externs.h
@@ -224,6 +224,8 @@ extern cptr keymap_act[KEYMAP_MODES][256];
 extern s16b command_cmd;
 extern s16b command_dir;
 extern event_type command_cmd_ex;
+extern bool command_aborted;
+extern bool executing_macro;
 
 extern custom_command_type custom_command[MAX_CUSTOM_COMMANDS];
 extern int custom_commands;

--- a/src/client/c-files.c
+++ b/src/client/c-files.c
@@ -382,6 +382,10 @@ void text_to_ascii(char *buf, size_t max, cptr str)
 			/* MAngband-specific: feed queue */
 			else if (*str == 'f') *s++ = '\f';
 
+			/* MAngband-specific: AND and OR "operators" */
+			else if (*str == '&') *s++ = '\x0E';
+			else if (*str == '|') *s++ = '\x0F';
+
 			/* Octal-mode */
 			else if (*str == '0')
 			{

--- a/src/client/c-inven.c
+++ b/src/client/c-inven.c
@@ -600,6 +600,7 @@ bool c_get_item(int *cp, cptr pmt, bool equip, bool inven, bool floor)
 				if (!inven || !equip)
 				{
 					bell();
+					if (executing_macro) done = TRUE;
 					break;
 				}
 
@@ -646,6 +647,7 @@ bool c_get_item(int *cp, cptr pmt, bool equip, bool inven, bool floor)
 				if (!get_tag(&k, which))
 				{
 					bell();
+					if (executing_macro) done = TRUE;
 					break;
 				}
 
@@ -653,6 +655,7 @@ bool c_get_item(int *cp, cptr pmt, bool equip, bool inven, bool floor)
 				if ((k < INVEN_WIELD) ? !inven : !equip)
 				{
 					bell();
+					if (executing_macro) done = TRUE;
 					break;
 				}
 
@@ -660,6 +663,7 @@ bool c_get_item(int *cp, cptr pmt, bool equip, bool inven, bool floor)
 				if (!get_item_okay(k))
 				{
 					bell();
+					if (executing_macro) done = TRUE;
 					break;
 				}
 
@@ -697,6 +701,7 @@ bool c_get_item(int *cp, cptr pmt, bool equip, bool inven, bool floor)
 				if (!get_item_okay(k))
 				{
 					bell();
+					if (executing_macro) done = TRUE;
 					break;
 				}
 
@@ -754,6 +759,7 @@ bool c_get_item(int *cp, cptr pmt, bool equip, bool inven, bool floor)
 				if (!get_item_okay(k))
 				{
 					bell();
+					if (executing_macro) done = TRUE;
 					break;
 				}
 

--- a/src/client/c-spell.c
+++ b/src/client/c-spell.c
@@ -236,6 +236,7 @@ int get_spell(int *sn, cptr p, cptr prompt, int *bn, bool known, bool bookless)
 			else if (r < 0)
 			{
 				bell();
+				if (executing_macro) flag = TRUE;
 			}
 			continue;
 		}
@@ -345,6 +346,7 @@ int get_spell(int *sn, cptr p, cptr prompt, int *bn, bool known, bool bookless)
 		if (i < 0)
 		{
 			bell();
+			if (executing_macro) flag = TRUE;
 			continue;
 		}
 

--- a/src/client/c-util.c
+++ b/src/client/c-util.c
@@ -13,6 +13,8 @@ static bool strip_chars = FALSE;
 
 #define flush_later inkey_xtra
 
+#define suppress_flush executing_macro
+
 static byte macro__use[256];
 
 static char octify(uint i)
@@ -39,6 +41,7 @@ void flush_now(void)
 {
 	/* Clear various flags */
 	flush_later = FALSE;
+	suppress_flush = FALSE;
 
 	/* Cancel "macro" info */
 	parse_macro = after_macro = FALSE;
@@ -324,6 +327,23 @@ static event_type inkey_aux(void)
 	/* Cancel queue clearing */
 	if (ch == '\f' && parse_macro) { first_escape = FALSE; return (ke0); }
 
+	/* Hack -- Ignore aborted macros */
+	if (command_aborted && parse_macro)
+	{
+		/* UNLESS we see logcal AND ('0x0E')... */
+		if (ch == 0x0E)	command_aborted = 2;
+		/* ... we allow logical OR ('0x0F') to un-abort */
+		else if (command_aborted < 2 && ch == 0x0F)
+			command_aborted = FALSE; /* UN-abort macro */
+		return (ke0);
+	}
+	/* Hack -- Pretend we aborted a macro on logical OR ('0x0F') */
+	else if (parse_macro && !command_aborted && ch == 0x0F)
+	{
+		command_aborted = 2;
+		return (ke0);
+	}
+
 	/* Do not check macro actions */
 	if (parse_macro) return (ke);
 
@@ -449,6 +469,9 @@ static event_type inkey_aux(void)
 	/* Push the macro "action" onto the key queue */
 	while (n > 0)
 	{
+		/* Evil Hack -- if we see logical OR (ascii '0x0F'), suppress flush! */
+		if (act[n-1] == '\x0F') suppress_flush = TRUE;
+
 		/* Push the key, notice over-flow */
 		if (Term_key_push(act[--n])) return (ke0);
 	}
@@ -602,6 +625,10 @@ event_type inkey_ex(void)
 		/* Cancel arcane flags */
 		parse_slash = after_macro = FALSE;
 		strip_chars = FALSE;
+
+		/* Cancel "new" evil flags */
+		suppress_flush = FALSE;
+		command_aborted = FALSE;
 
 		/* Forget old keypresses */
 		Term_flush();
@@ -778,6 +805,9 @@ event_type inkey_ex(void)
 		
 			/* End "macro trigger" */
 			parse_under = FALSE;
+
+			/* Macro has ended, stop ignoring commands */
+			command_aborted = FALSE;
 
 			/* Stop stripping */
 			strip_chars = FALSE;
@@ -1027,6 +1057,13 @@ void bell(void)
 
 	/* Make a bell noise (if allowed) */
 	if (ring_bell) Term_xtra(TERM_XTRA_NOISE, 0);
+
+	/* Mark command as aborted */
+	command_aborted = TRUE;
+
+	/* MEGA-Hack: DO NOT flush WHOLE input, let
+	 * "command_abort" mechanism take care of it. */
+	if (suppress_flush) return;
 
 	/* Flush the input (later!) */
 	flush();
@@ -2894,11 +2931,15 @@ void ascii_to_text(char *buf, size_t len, cptr str)
 			*s++ = '\\';
 			*s++ = '\\';
 		}
+
 		else if (i == '\f')
 		{
 			*s++ = '\\';
 			*s++ = 'f';
 		}
+		/* MAngband-specific: AND and OR "operators" */
+		else if (i == '\x0E') {	*s++ = '\\'; *s++ = '&'; }
+		else if (i == '\x0F') {	*s++ = '\\'; *s++ = '|'; }
 
 		/* Macro Trigger */
 		else if (i == 31)

--- a/src/client/c-variable.c
+++ b/src/client/c-variable.c
@@ -170,6 +170,8 @@ cptr keymap_act[KEYMAP_MODES][256]; /* Keymaps for each "mode" associated with e
 s16b command_cmd;
 s16b command_dir;
 event_type command_cmd_ex; /* Gives additional information of current command */
+bool command_aborted = FALSE; /* Hack -- set to TRUE to ignore the "rest of macro" */
+bool executing_macro = FALSE; /* READ-ONLY!!! Keep track of "real" vs "macro-induced" keystrokes */
 
 custom_command_type custom_command[MAX_CUSTOM_COMMANDS];
 int custom_commands;


### PR DESCRIPTION
This adds a "simple" (read: hacky) mechanism for macro overloading.

It works by suppressing input flush on errors. Instead, we continue to execute our macro, ignoring certain keys, as appropriate, until we hit the next "viable" macro part.

Important note: #776 discussed things, like spell failing due to being out of mana, or staff not working due to being out of charges. This mechanism can not and will not handle such cases. If it happens server-side, we have no way of telling what will happen, so this is a client-only feature.

It will be most useful for situations when you miss some items (likely due to running out, or suffering from a "destroy item" monster attack).

The syntax is:
`\eq1\|\eu1\|\ez1`.

(That is a pipe symbol, as in "logical OR". We can't use the pipe verbatim, cause it's an actual command (unique list), nor can we use ampersand (DM menu), nor the question mark (read help), proposed in the original ticket. But I think escaping with slash is a nice approximation.)

Another note: #776 proposed a different syntax, which looked similar to C ternary operator. The syntax in this PR is more similar to logical chaining, seen in scripting languages (e.g. `make & ./mangclient & echo "Done"`). I hope it's all the same to you.

You can also use the `\&` "operator" (aka "logical AND"), which doesn't make A LOT of sense, as it's always implied anyway, but still can be useful in some situations. You might want to use it to STOP the chain from going to the next `\|`.

The `\&` operator has precedence to `\|`. We don't have parenthesis, so grouping isn't supported :)