### PR TITLE
Update Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,23 +50,24 @@ matrix:
           - android-26
           - build-tools-28.0.2
       install:
-        - echo y | sdkmanager "ndk-bundle"
+        - echo y | sdkmanager "ndk;21.4.7075529"
       before_script:
-        - export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
+        - export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.4.7075529
         - export SDL_VERSION="2.0.10"
         - export SDL_TTF_VERSION="2.0.15"
         - cd build/asgradle
-        - wget https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
+        - wget --no-check-certificate https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
         - tar -xzf SDL2-${SDL_VERSION}.tar.gz
         - cp -r SDL2-${SDL_VERSION}/android-project/gradle .
         - mv SDL2-${SDL_VERSION} mangclient/jni/SDL2
-        - wget https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
+        - wget --no-check-certificate https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
         - tar -xzf SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
         - mv SDL2_ttf-${SDL_TTF_VERSION} mangclient/jni/SDL2_ttf
         - ln -s ../../../../../../lib mangclient/src/main/assets/lib
       script:
         - ./gradlew build connectedCheck assembleDebug assembleRelease
-      before_deploy:
+      after_success:
+        # travis runs "before_deploy" multiple times, but one is enough, so we use "after_success" instead
         - cp mangclient/build/outputs/apk/debug/mangclient-debug.apk ../../.
         - cp mangclient/build/outputs/apk/release/mangclient-release-unsigned.apk ../../.
         - rm -rf mangclient # kill temp files

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ addons:
     branch_pattern: coverity_scan
 
 before_install:
-  - export HOMEBREW_FORCE_BREWED_CURL=1 
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo insecure >> ~/.curlrc; fi
 #  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$SDL" == "1" ]]; then brew update     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$SDL" == "1" ]]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install sdl; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$SDL" == "1" ]]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install sdl_ttf; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,11 +82,11 @@ matrix:
         - export SDL_VERSION="2.0.12"
         - export SDL_TTF_VERSION="2.0.15"
         - cd ..
-        - curl -O https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
+        - curl -k -O https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
         - tar -xzf SDL2-${SDL_VERSION}.tar.gz
         # Our xcode project expects to find "SDL" dir, not "SDL2-2.X.Y"
         - mv SDL2-${SDL_VERSION} SDL
-        - curl -O https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
+        - curl -k -O https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
         - tar -xzf SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
         # Same for SDL2_ttf, let's strip away version number
         - mv SDL2_ttf-${SDL_TTF_VERSION} SDL2_ttf

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
         - rm -rf mangclient # kill temp files
         - ./.travis-gh.sh > ../../index.html
 
-    - language: objective-c
+    - language: generic
       os: osx
       osx_image: xcode9.4
       compiler: ""
@@ -125,6 +125,7 @@ addons:
     branch_pattern: coverity_scan
 
 before_install:
+  - export HOMEBREW_FORCE_BREWED_CURL=1 
 #  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$SDL" == "1" ]]; then brew update     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$SDL" == "1" ]]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install sdl; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$SDL" == "1" ]]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install sdl_ttf; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ addons:
     branch_pattern: coverity_scan
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo insecure >> ~/.curlrc; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo insecure >> ~/.curlrc; export HOMEBREW_CURLRC=1 ; fi
 #  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$SDL" == "1" ]]; then brew update     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$SDL" == "1" ]]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install sdl; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$SDL" == "1" ]]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install sdl_ttf; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       env: CONFIGURE_FLAGS="--with-gcu --without-x11 --without-sdl --with-sdl2" SDL="2"
   include:
     - language: android
-      dist: xenial
+      dist: trusty
       jdk: oraclejdk8
       compiler: "" # Remove desktop compiler
       env: BUILDING_FOR_ANDROID="YES" SDL="2"
@@ -56,11 +56,11 @@ matrix:
         - export SDL_VERSION="2.0.10"
         - export SDL_TTF_VERSION="2.0.15"
         - cd build/asgradle
-        - wget https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
+        - wget --no-check-certificate https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
         - tar -xzf SDL2-${SDL_VERSION}.tar.gz
         - cp -r SDL2-${SDL_VERSION}/android-project/gradle .
         - mv SDL2-${SDL_VERSION} mangclient/jni/SDL2
-        - wget https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
+        - wget --no-check-certificate https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
         - tar -xzf SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
         - mv SDL2_ttf-${SDL_TTF_VERSION} mangclient/jni/SDL2_ttf
         - ln -s ../../../../../../lib mangclient/src/main/assets/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       env: CONFIGURE_FLAGS="--with-gcu --without-x11 --without-sdl --with-sdl2" SDL="2"
   include:
     - language: android
-      dist: trusty
+      dist: xenial
       jdk: oraclejdk8
       compiler: "" # Remove desktop compiler
       env: BUILDING_FOR_ANDROID="YES" SDL="2"
@@ -56,11 +56,11 @@ matrix:
         - export SDL_VERSION="2.0.10"
         - export SDL_TTF_VERSION="2.0.15"
         - cd build/asgradle
-        - wget --no-check-certificate https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
+        - wget https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
         - tar -xzf SDL2-${SDL_VERSION}.tar.gz
         - cp -r SDL2-${SDL_VERSION}/android-project/gradle .
         - mv SDL2-${SDL_VERSION} mangclient/jni/SDL2
-        - wget --no-check-certificate https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
+        - wget https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
         - tar -xzf SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
         - mv SDL2_ttf-${SDL_TTF_VERSION} mangclient/jni/SDL2_ttf
         - ln -s ../../../../../../lib mangclient/src/main/assets/lib

--- a/src/client/osx/Makefile.am
+++ b/src/client/osx/Makefile.am
@@ -31,7 +31,7 @@ mangclient.app: mangclient
 	@mkdir mangclient.app/Contents/Resources/lib/xtra/Sound
 	@cp mangclient mangclient.app/Contents/MacOS
 	@$(eval DYLIBS=$(shell otool -L mangclient | grep SDL | awk -F' ' '{ print $$1 }'))
-	for dylib in ${DYLIBS} ; do \
+	@for dylib in ${DYLIBS} ; do \
 		NAME=`basename $$dylib` ; \
 		echo "dylib: $$dylib -> $$NAME" ; \
 		cp $$dylib mangclient.app/Contents/MacOS/ ; \
@@ -48,8 +48,8 @@ mangclient.app: mangclient
 				install_name_tool -change $$subdylib @executable_path/$$SUBNAME mangclient.app/Contents/MacOS/$$NAME; \
 			fi ; \
 		done ; \
-		chmod -w mangclient.app/Contents/MacOS/*.dylib ; \
 	done
+	@chmod -w mangclient.app/Contents/MacOS/*.dylib ; \
 	@cp src/client/osx/launch_mangclient.sh mangclient.app/Contents/MacOS
 	@cp src/client/osx/mangclient.icns mangclient.app/Contents/Resources
 	@cp src/client/osx/Info.plist mangclient.app/Contents

--- a/src/client/osx/Makefile.am
+++ b/src/client/osx/Makefile.am
@@ -31,10 +31,11 @@ mangclient.app: mangclient
 	@mkdir mangclient.app/Contents/Resources/lib/xtra/Sound
 	@cp mangclient mangclient.app/Contents/MacOS
 	@$(eval DYLIBS=$(shell otool -L mangclient | grep SDL | awk -F' ' '{ print $$1 }'))
-	@for dylib in ${DYLIBS} ; do \
+	for dylib in ${DYLIBS} ; do \
 		NAME=`basename $$dylib` ; \
 		echo "dylib: $$dylib -> $$NAME" ; \
 		cp $$dylib mangclient.app/Contents/MacOS/ ; \
+		chmod +w mangclient.app/Contents/MacOS/$$NAME ; \
 		install_name_tool -change $$dylib @executable_path/$$NAME mangclient.app/Contents/MacOS/mangclient ; \
 		SUB_DYLIBS=`otool -L $$dylib | grep -e freetype -e SDL | grep -v ':' | awk -F' ' '{ print $$1 }'` ; \
 		for subdylib in $${SUB_DYLIBS} ; do \
@@ -45,9 +46,9 @@ mangclient.app: mangclient
 				chmod +w mangclient.app/Contents/MacOS/$$SUBNAME ; \
 				ls -l mangclient.app/Contents/MacOS/ ; \
 				install_name_tool -change $$subdylib @executable_path/$$SUBNAME mangclient.app/Contents/MacOS/$$NAME; \
-				chmod -w mangclient.app/Contents/MacOS/$$SUBNAME ; \
 			fi ; \
 		done ; \
+		chmod -w mangclient.app/Contents/MacOS/*.dylib ; \
 	done
 	@cp src/client/osx/launch_mangclient.sh mangclient.app/Contents/MacOS
 	@cp src/client/osx/mangclient.icns mangclient.app/Contents/Resources

--- a/src/client/osx/Makefile.am
+++ b/src/client/osx/Makefile.am
@@ -44,7 +44,6 @@ mangclient.app: mangclient
 				echo "sub_dylib: $$subdylib -> $$SUBNAME" ; \
 				cp $$subdylib mangclient.app/Contents/MacOS/ ; \
 				chmod +w mangclient.app/Contents/MacOS/$$SUBNAME ; \
-				ls -l mangclient.app/Contents/MacOS/ ; \
 				install_name_tool -change $$subdylib @executable_path/$$SUBNAME mangclient.app/Contents/MacOS/$$NAME; \
 			fi ; \
 		done ; \

--- a/src/client/osx/Makefile.am
+++ b/src/client/osx/Makefile.am
@@ -42,7 +42,9 @@ mangclient.app: mangclient
 			if [ $$NAME != $$SUBNAME ] ; then \
 				echo "sub_dylib: $$subdylib -> $$SUBNAME" ; \
 				cp $$subdylib mangclient.app/Contents/MacOS/ ; \
+				chmod +w mangclient.app/Contents/MacOS/$$SUBNAME ; \
 				install_name_tool -change $$subdylib @executable_path/$$SUBNAME mangclient.app/Contents/MacOS/$$NAME; \
+				chmod -w mangclient.app/Contents/MacOS/$$SUBNAME ; \
 			fi ; \
 		done ; \
 	done

--- a/src/client/osx/Makefile.am
+++ b/src/client/osx/Makefile.am
@@ -43,6 +43,7 @@ mangclient.app: mangclient
 				echo "sub_dylib: $$subdylib -> $$SUBNAME" ; \
 				cp $$subdylib mangclient.app/Contents/MacOS/ ; \
 				chmod +w mangclient.app/Contents/MacOS/$$SUBNAME ; \
+				ls -l mangclient.app/Contents/MacOS/ ; \
 				install_name_tool -change $$subdylib @executable_path/$$SUBNAME mangclient.app/Contents/MacOS/$$NAME; \
 				chmod -w mangclient.app/Contents/MacOS/$$SUBNAME ; \
 			fi ; \


### PR DESCRIPTION
Our Travis-CI builds deteriorated over time, this PR aims to fix all current issues.

1. Android:
   1. On android, NDK is pinned to version 21.4.7075529, because newer version conflict with older gradle.
   2. We should probably update our project and/or SDL2 version.
2. macOS:
   1. fix a bug in App Bundle assembler, it was failing to update embedded .dylib's due to permission errors, on some systems.
2. macOS, Android:
   1. looks like the images we run off got outdated certificates, and I'm not sure how to update them.
   2. thus, `-k`, `--insecure` was added everywhere, including curl-that-is-being-called-by-homebrew.
3. generic:
    1. travis was calling "before_deploy" step too many times (although, according to their vauge documentation, that shouldn't be happing), so this script is moved to "after_script" sections.

P.S. In any case, travis changed their FOSS support policy, so I don't think we shall be using them anymore, and shall look for alternatives. Just want to leave a working build, for reference, before yanking them out.