### PR TITLE
Add GitHub Actions CI/CD workflow.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,575 @@
+name: ci-cd
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+  release:
+    types:
+      - created
+jobs:
+  vs2017:
+    runs-on: windows-2016
+    steps:
+      - uses: actions/checkout@v2
+      - uses: microsoft/setup-msbuild@v1.0.2
+      - name: Install Windows 8.1 SDK
+        shell: powershell
+        run: |
+          Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=323507 -OutFile sdksetup.exe -UseBasicParsing
+          Start-Process -Wait sdksetup.exe -ArgumentList "/q", "/norestart", "/features", "OptionId.WindowsDesktopSoftwareDevelopmentKit", "OptionId.NetFxSoftwareDevelopmentKit"
+      - run: |
+          msbuild build/vs2017/mangband.sln
+
+  win32:
+    strategy:
+      matrix:
+        include:
+        # - { sys: mingw64, env: x86_64 }
+          - { sys: mingw32, env: i686 }
+    runs-on: windows-2016
+    outputs:
+      version: ${{steps.get_version.outputs.version}}
+      ref_short: ${{steps.get_version.outputs.ref_short}}
+      ref_hash: ${{steps.get_version.outputs.ref_hash}}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          msystem: ${{matrix.sys}}
+          install: >-
+            automake
+            autoconf
+            make
+            mingw-w64-${{matrix.env}}-gcc
+            mingw-w64-${{matrix.env}}-SDL
+            mingw-w64-${{matrix.env}}-SDL_ttf
+            mingw-w64-${{matrix.env}}-SDL2
+            mingw-w64-${{matrix.env}}-SDL2_ttf
+      - id: get_version
+        shell: msys2 {0}
+        run: |
+          VERSION=`grep "AC_INIT" configure.ac | sed -e s/AC_INIT\(mangband,\ //g -e s/,\ team@mangband.org\)//g`
+          REF_SHORT=${GITHUB_REF#refs/heads/}
+          REF_SHORT=${REF_SHORT#refs/tags/}
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=ref_short::$REF_SHORT"
+          echo "::set-output name=ref_hash::$REF_SHORT-${GITHUB_SHA::7}"
+      - name: "Build SDL1.2 client"
+        shell: msys2 {0}
+        run: |
+          ./autogen.sh -n
+          ./configure --with-sdl --without-sdl2 --without-gcu --enable-win
+          make clean
+          make mangclient.exe
+          cp mangclient.exe mangclient-sdl.exe
+      - name: "Build SDL2 client"
+        shell: msys2 {0}
+        run: |
+          ./autogen.sh -n
+          ./configure --with-sdl --without-sdl2 --without-gcu --enable-win
+          make clean
+          make mangclient.exe
+          cp mangclient.exe mangclient-sdl2.exe
+      - name: "Build WIN32 client and server"
+        shell: msys2 {0}
+        run: |
+          ./autogen.sh -n
+          ./configure --without-sdl --without-sdl2 --without-gcu --enable-win
+          make clean
+          make
+      - name: "setup NuGet"
+        uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: '5.x'
+      - run: nuget install Tools.InnoSetup -Version 6.2.0
+      - shell: msys2 {0}
+        run: |
+          ls -l /${{matrix.sys}}/bin/*.dll
+          cp /${{matrix.sys}}/bin/SDL*.dll .
+          cp /${{matrix.sys}}/bin/*freetype*.dll .
+          cp /${{matrix.sys}}/bin/zlib*.dll .
+          ls -l
+      - shell: cmd
+        run: |
+          ISCC.exe "dist\exe\installer-client-win.iss" "/Q"
+          ISCC.exe "dist\exe\installer-server-win.iss" "/Q"
+      - shell: msys2 {0}
+        run: ls -l *.exe
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mangband-client-${{steps.get_version.outputs.ref_hash}}-setup.exe
+          path: dist/exe/mangband-client-setup-v${{steps.get_version.outputs.version}}.exe
+          if-no-files-found: error
+        if: matrix.env == 'i686'
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mangband-server-${{steps.get_version.outputs.ref_hash}}-setup.exe
+          path: dist/exe/mangband-server-setup-v${{steps.get_version.outputs.version}}.exe
+          if-no-files-found: error
+        if: matrix.env == 'i686'
+  upload_win32:
+    if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    needs: win32
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: mangband-server-${{needs.win32.outputs.ref_hash}}-setup.exe
+      - uses: actions/download-artifact@v2
+        with:
+          name: mangband-client-${{needs.win32.outputs.ref_hash}}-setup.exe
+      - name: Rename for upload
+        if: ${{ github.event_name == 'push' }}
+        run: |
+           mv mangband-client-setup-v${{needs.win32.outputs.version}}.exe mangband-client-setup-${{needs.win32.outputs.ref_hash}}.exe
+           mv mangband-server-setup-v${{needs.win32.outputs.version}}.exe mangband-server-setup-${{needs.win32.outputs.ref_hash}}.exe
+           ls -l
+      - name: Upload
+        if: ${{ github.event_name == 'push' }}
+        uses: softprops/action-gh-release@v1
+        # if: startsWith(github.ref, 'refs/tags/')
+        with:
+          repository: ${{github.repository_owner}}/mangband-builds
+          token: ${{secrets.BOT_GITHUB_TOKEN}}
+          name: ${{needs.win32.outputs.ref_short}}-windows
+          tag_name: ${{needs.win32.outputs.ref_short}}-windows
+          files: |
+            mangband-client-setup-${{needs.win32.outputs.ref_hash}}.exe
+            mangband-server-setup-${{needs.win32.outputs.ref_hash}}.exe
+      - name: Release
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            mangband-client-setup-v${{needs.win64.outputs.version}}.exe
+            mangband-server-setup-v${{needs.win64.outputs.version}}.exe
+
+  osx64:
+    runs-on: macos-10.15
+    outputs:
+      version: ${{steps.get_version.outputs.version}}
+      ref_short: ${{steps.get_version.outputs.ref_short}}
+      ref_hash: ${{steps.get_version.outputs.ref_hash}}
+    steps:
+      - uses: actions/checkout@v2
+      - id: get_version
+        shell: bash
+        run: |
+          VERSION=`grep "AC_INIT" configure.ac | sed -e s/AC_INIT\(mangband,\ //g -e s/,\ team@mangband.org\)//g`
+          REF_SHORT=${GITHUB_REF#refs/heads/}
+          REF_SHORT=${REF_SHORT#refs/tags/}
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=ref_short::$REF_SHORT"
+          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+      - name: setup Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - run: |
+          brew install automake autoconf
+          brew install sdl sdl_ttf
+          brew install sdl2 sdl2_ttf
+      - name: "Build SDL2 client"
+        shell: bash
+        run: |
+          ./autogen.sh -n
+          ./configure --without-sdl --with-sdl2 --without-gcu --without-crb
+          make clean
+          make mangclient.app
+          cp -r mangclient.app MAngbandClient${VERSION}-SDL2.app
+      - name: "Build SDL1.2 client"
+        shell: bash
+        run: |
+          ./autogen.sh -n
+          ./configure --with-sdl --without-sdl2 --without-gcu --without-crb
+          make clean
+          make mangclient.app
+      - name: "Build server"
+        shell: bash
+        run: |
+          make mangband
+      - name: "DMG client"
+        shell: bash
+        run: |
+          ./dist/dmg/dmgit.sh MAngbandClient${VERSION}-SDL2.app
+      - name: "DMG server"
+        shell: bash
+        run: |
+          ./dist/dmg/dmgserv.sh
+      - run: ls -lR
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mangclient-${{steps.get_version.outputs.version}}-osx-intel.dmg
+          path: mangclient-${{steps.get_version.outputs.version}}-osx-intel.dmg
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mangband-${{steps.get_version.outputs.version}}-osx-intel.dmg
+          path: mangband-${{steps.get_version.outputs.version}}-osx-intel.dmg
+          if-no-files-found: error
+  upload_osx64:
+    if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    needs: osx64
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: mangband-${{needs.osx64.outputs.version}}-osx-intel.dmg
+      - uses: actions/download-artifact@v2
+        with:
+          name: mangclient-${{needs.osx64.outputs.version}}-osx-intel.dmg
+      - name: Rename for upload
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          mv mangband-${{needs.osx64.outputs.version}}-osx-intel.dmg mangband-${{needs.osx64.outputs.ref_hash}}-osx-intel.dmg
+          mv mangclient-${{needs.osx64.outputs.version}}-osx-intel.dmg mangclient-${{needs.osx64.outputs.ref_hash}}-osx-intel.dmg
+      - name: Upload
+        if: ${{ github.event_name == 'push' }}
+        uses: softprops/action-gh-release@v1
+        # if: startsWith(github.ref, 'refs/tags/')
+        with:
+          repository: ${{github.repository_owner}}/mangband-builds
+          token: ${{secrets.BOT_GITHUB_TOKEN}}
+          name: ${{needs.osx64.outputs.ref_short}}-osx
+          tag_name: ${{needs.osx64.outputs.ref_short}}-osx
+          files: |
+            mangband-${{needs.osx64.outputs.ref_hash}}-osx-intel.dmg
+            mangclient-${{needs.osx64.outputs.ref_hash}}-osx-intel.dmg
+      - name: Release
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            mangband-${{needs.osx64.outputs.version}}-osx-intel.dmg
+            mangclient-${{needs.osx64.outputs.version}}-osx-intel.dmg
+  xcode:
+    runs-on: macos-10.15
+    outputs:
+      version: ${{steps.get_version.outputs.version}}
+      ref_short: ${{steps.get_version.outputs.ref_short}}
+      ref_hash: ${{steps.get_version.outputs.ref_hash}}
+    steps:
+      - uses: actions/checkout@v2
+      - id: get_version
+        shell: bash
+        run: |
+          VERSION=`grep "AC_INIT" configure.ac | sed -e s/AC_INIT\(mangband,\ //g -e s/,\ team@mangband.org\)//g`
+          REF_SHORT=${GITHUB_REF#refs/heads/}
+          REF_SHORT=${REF_SHORT#refs/tags/}
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=ref_short::$REF_SHORT"
+          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+      - run: |
+          export SDL_VERSION="2.0.16"
+          export SDL_TTF_VERSION="2.0.15"
+          curl -O http://libsdl.org/release/SDL2-${SDL_VERSION}.dmg
+          curl -O https://www.libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.dmg
+          hdiutil attach SDL2-${SDL_VERSION}.dmg
+          hdiutil attach SDL2_ttf-${SDL_TTF_VERSION}.dmg
+          cp -r /Volumes/SDL2/SDL2.framework build/xcode/.
+          cp -r /Volumes/SDL2_ttf/SDL2_ttf.framework build/xcode/.
+      - run: |
+          cd build/xcode
+          xcodebuild -project mangclient.xcodeproj -scheme "mangclient" build CONFIGURATION_BUILD_DIR="./build/Release-macos" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED="NO" CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+
+
+  ios:
+    runs-on: macos-10.15
+    outputs:
+      version: ${{steps.get_version.outputs.version}}
+      ref_short: ${{steps.get_version.outputs.ref_short}}
+      ref_hash: ${{steps.get_version.outputs.ref_hash}}
+    steps:
+      - uses: actions/checkout@v2
+      - id: get_version
+        shell: bash
+        run: |
+          VERSION=`grep "AC_INIT" configure.ac | sed -e s/AC_INIT\(mangband,\ //g -e s/,\ team@mangband.org\)//g`
+          REF_SHORT=${GITHUB_REF#refs/heads/}
+          REF_SHORT=${REF_SHORT#refs/tags/}
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=ref_short::$REF_SHORT"
+          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+      - run: |
+          export SDL_VERSION="2.0.16"
+          export SDL_TTF_VERSION="2.0.15"
+          cd ..
+          curl -O https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
+          tar -xzf SDL2-${SDL_VERSION}.tar.gz
+          # Our xcode project expects to find "SDL" dir, not "SDL2-2.X.Y"
+          mv SDL2-${SDL_VERSION} SDL
+          curl -O https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
+          tar -xzf SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
+          # Same for SDL2_ttf, let's strip away version number
+          mv SDL2_ttf-${SDL_TTF_VERSION} SDL2_ttf
+          # Hack for newer SDL versions
+          # cp -r SDL/Xcode/SDL/SDL.xcodeproj SDL/XCode-iOS/SDL/.
+          xcodebuild -project SDL/Xcode/SDL/SDL.xcodeproj -list
+      - run: |
+          cd build/xcode-ios
+          xcodebuild -project mangclient-ios.xcodeproj -list
+          xcodebuild -project mangclient-ios.xcodeproj -scheme "Static Library-iOS" CONFIGURATION_BUILD_DIR="./build/Debug" -configuration Debug ONLY_ACTIVE_ARCH="YES"
+          xcodebuild -project mangclient-ios.xcodeproj -scheme "libSDL_ttf-iOS" CONFIGURATION_BUILD_DIR="./build/Debug-iphoneos" -configuration Debug ONLY_ACTIVE_ARCH="YES" -destination generic/platform=iOS
+          xcodebuild -project mangclient-ios.xcodeproj build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED="NO" CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO" -configuration Debug ONLY_ACTIVE_ARCH="YES"
+  android:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.get_version.outputs.version}}
+      ref_short: ${{steps.get_version.outputs.ref_short}}
+      ref_hash: ${{steps.get_version.outputs.ref_hash}}
+    steps:
+      - uses: actions/checkout@v1
+      - id: get_version
+        run: |
+          VERSION=`grep "AC_INIT" configure.ac | sed -e s/AC_INIT\(mangband,\ //g -e s/,\ team@mangband.org\)//g`
+          REF_SHORT=${GITHUB_REF#refs/heads/}
+          REF_SHORT=${REF_SHORT#refs/tags/}
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=ref_short::$REF_SHORT"
+          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
+      - name: "Vendor-drop SDL2 and ln -s assets folder"
+        shell: bash
+        run: |
+         export SDL_VERSION="2.0.10"
+         export SDL_TTF_VERSION="2.0.15"
+         cd build/asgradle
+         wget https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
+         tar -xzf SDL2-${SDL_VERSION}.tar.gz
+         cp -r SDL2-${SDL_VERSION}/android-project/gradle .
+         mv SDL2-${SDL_VERSION} mangclient/jni/SDL2
+         wget https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
+         tar -xzf SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
+         mv SDL2_ttf-${SDL_TTF_VERSION} mangclient/jni/SDL2_ttf
+         ln -s ../../../../../../lib mangclient/src/main/assets/lib
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: build connectedCheck assembleDebug assembleRelease
+          build-root-directory: build/asgradle
+          gradle-executable: build/asgradle/gradlew
+          distributions-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+      - shell: bash
+        run: |
+          cd build/asgradle
+          cp mangclient/build/outputs/apk/debug/mangclient-debug.apk ../../.
+          cp mangclient/build/outputs/apk/release/mangclient-release-unsigned.apk ../../.
+          rm -rf mangclient # kill temp files
+          ./.travis-gh.sh > ../../index.html
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mangclient-debug.apk
+          path: mangclient-debug.apk
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mangclient-release-unsigned.apk
+          path: mangclient-release-unsigned.apk
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: index.html
+          path: index.html
+  upload_android:
+    if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    needs: android
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: mangclient-debug.apk
+      - uses: actions/download-artifact@v2
+        with:
+          name: mangclient-release-unsigned.apk
+      - uses: actions/download-artifact@v2
+        with:
+          name: index.html
+      - name: Upload
+        if: ${{ github.event_name == 'push' }}
+        uses: softprops/action-gh-release@v1
+        # if: startsWith(github.ref, 'refs/tags/')
+        with:
+          repository: ${{github.repository_owner}}/mangband-builds
+          token: ${{secrets.BOT_GITHUB_TOKEN}}
+          name: ${{needs.android.outputs.ref_short}}-android
+          tag_name: ${{needs.android.outputs.ref_short}}-android
+          files: |
+            mangclient-debug.apk
+            mangclient-release-unsigned.apk
+            index.html
+      - name: Release
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            mangclient-debug.apk
+            mangclient-release-unsigned.apk
+  # debian-based appimage build. would've preferred centos6.
+  appimage:
+    strategy:
+      matrix:
+        include:
+          - { image: "debian:9", arch: "x86_64" }
+          - { image: "i386/debian:9", arch: "i386" }
+    runs-on: ubuntu-latest
+    container:
+      image: docker://${{matrix.image}}
+    outputs:
+      version: ${{steps.get_version.outputs.version}}
+      ref_short: ${{steps.get_version.outputs.ref_short}}
+      ref_hash: ${{steps.get_version.outputs.ref_hash}}
+    steps:
+      - uses: actions/checkout@v1
+      - id: get_version
+        run: |
+          VERSION=`grep "AC_INIT" configure.ac | sed -e s/AC_INIT\(mangband,\ //g -e s/,\ team@mangband.org\)//g`
+          REF_SHORT=${GITHUB_REF#refs/heads/}
+          REF_SHORT=${REF_SHORT#refs/tags/}
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=ref_short::$REF_SHORT"
+          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA}"
+      - name: apt-get install build deps
+        run: |
+          apt-get update -qq
+          apt-get install -yqq make gcc autoconf automake dh-make wget >/dev/null
+          apt-get install -yqq dpkg-dev # needed on Ubuntu14 >/dev/null
+          apt-get install -yqq libncurses5-dev libsdl1.2-dev libsdl2-dev >/dev/null
+          apt-get install -yqq libsdl-ttf2.0-dev libsdl2-ttf-dev >/dev/null
+          apt-get install -yqq libX11-dev >/dev/null || apt-get install -y libx11-dev >/dev/null
+      - name: Build SDL1.2 + GCU client
+        run: |
+          ./autogen.sh -n
+          ./configure --with-gcu --with-sdl --without-x11
+          make
+          rm -f *.AppImage
+          export ARCH=${{matrix.arch}}
+          export VERSION=${{steps.get_version.outputs.version}}
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${ARCH}.AppImage
+          chmod +x ./*.AppImage
+          export LINUX_DEPLOY="$(pwd)/linuxdeploy-${ARCH}.AppImage --appimage-extract-and-run"
+          dist/appimage/appit.sh --without-x11 --with-gcu --with-sdl
+          mv MAngbandClient-${VERSION}.AppImage MAngbandClient-${VERSION}-${{matrix.arch}}.AppImage
+          ls -l *.AppImage
+      - uses: actions/upload-artifact@v1
+        with:
+          name: MAngbandClient-${{steps.get_version.outputs.ref_hash}}-${{matrix.arch}}.AppImage
+          path: MAngbandClient-${{steps.get_version.outputs.version}}-${{matrix.arch}}.AppImage
+          if-no-files-found: error
+  upload_appimage:
+    if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    needs: appimage
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: MAngbandClient-${{needs.appimage.outputs.ref_hash}}-i386.AppImage
+      - uses: actions/download-artifact@v2
+        with:
+          name: MAngbandClient-${{needs.appimage.outputs.ref_hash}}-x86_64.AppImage
+      - run: |
+          ls -lR
+      - run: |
+          echo ${{needs.appimage.outputs.ref_short}}
+      - name: Rename for upload
+        if: ${{ github.event_name == 'push' }}
+        run: |
+           mv MAngbandClient-${{needs.appimage.outputs.version}}-i386.AppImage MAngbandClient-${{needs.appimage.outputs.ref_hash}}-i386.AppImage
+           mv MAngbandClient-${{needs.appimage.outputs.version}}-x86_64.AppImage MAngbandClient-${{needs.appimage.outputs.ref_hash}}-x86_64.AppImage
+      - name: Upload
+        if: ${{ github.event_name == 'push' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: ${{github.repository_owner}}/mangband-builds
+          token: ${{secrets.BOT_GITHUB_TOKEN}}
+          name: ${{needs.appimage.outputs.ref_short}}-appimage
+          tag_name: ${{needs.appimage.outputs.ref_short}}-appimage
+          files: |
+            MAngbandClient-${{needs.appimage.outputs.ref_hash}}-i386.AppImage
+            MAngbandClient-${{needs.appimage.outputs.ref_hash}}-x86_64.AppImage
+      - name: Release
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            MAngbandClient-${{needs.appimage.outputs.version}}-i386.AppImage
+            MAngbandClient-${{needs.appimage.outputs.version}}-x86_64.AppImage
+
+  linux:
+    strategy:
+      matrix:
+        include:
+          - { name: "GCU",   cfg: "--with-gcu --without-x11 --without-sdl --without-sdl2" }
+          - { name: "X11",   cfg: "--without-gcu --with-x11 --without-sdl --without-sdl2" }
+          - { name: "SDL1.2",cfg: "--without-gcu --without-x11 --with-sdl --without-sdl2" }
+          - { name: "SDL2",  cfg: "--without-gcu --without-x11 --without-sdl --with-sdl2" }
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.get_version.outputs.version}}
+      ref_short: ${{steps.get_version.outputs.ref_short}}
+      ref_hash: ${{steps.get_version.outputs.ref_hash}}
+    steps:
+      - uses: actions/checkout@v1
+      - id: get_version
+        run: |
+          VERSION=`grep "AC_INIT" configure.ac | sed -e s/AC_INIT\(mangband,\ //g -e s/,\ team@mangband.org\)//g`
+          REF_SHORT=${GITHUB_REF#refs/heads/}
+          REF_SHORT=${REF_SHORT#refs/tags/}
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=ref_short::$REF_SHORT"
+          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+      - name: apt-get install build deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -yqq make gcc autoconf automake dh-make wget >/dev/null
+          sudo apt-get install -yqq dpkg-dev # needed on Ubuntu14 >/dev/null
+          sudo apt-get install -yqq libncurses5-dev libsdl1.2-dev libsdl2-dev >/dev/null
+          sudo apt-get install -yqq libsdl-ttf2.0-dev libsdl2-ttf-dev >/dev/null
+          sudo apt-get install -yqq libX11-dev >/dev/null || sudo apt-get install -y libx11-dev >/dev/null
+      - name: Build ${{matrix.name}}
+        shell: bash
+        run: |
+          ./autogen.sh -n
+          ./configure ${{matrix.cfg}}
+          make clean
+          make mangclient
+
+  source:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.get_version.outputs.version}}
+      ref_short: ${{steps.get_version.outputs.ref_short}}
+      ref_hash: ${{steps.get_version.outputs.ref_hash}}
+    steps:
+      - uses: actions/checkout@v1
+      - id: get_version
+        run: |
+          VERSION=`grep "AC_INIT" configure.ac | sed -e s/AC_INIT\(mangband,\ //g -e s/,\ team@mangband.org\)//g`
+          REF_SHORT=${GITHUB_REF#refs/heads/}
+          REF_SHORT=${REF_SHORT#refs/tags/}
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=ref_short::$REF_SHORT"
+          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+      - name: apt-get install build deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -yqq make gcc autoconf automake dh-make wget >/dev/null
+          sudo apt-get install -yqq dpkg-dev # needed on Ubuntu14 >/dev/null
+      - name: make dist
+        shell: bash
+        run: |
+          ./autogen.sh -n
+          ./configure
+          make dist
+

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,7 +57,8 @@ jobs:
           REF_SHORT=${REF_SHORT#refs/tags/}
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=ref_short::$REF_SHORT"
-          echo "::set-output name=ref_hash::$REF_SHORT-${GITHUB_SHA::7}"
+          #echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          echo "::set-output name=ref_hash::${GITHUB_SHA::7}"
       - name: "Build SDL1.2 client"
         shell: msys2 {0}
         run: |
@@ -164,7 +165,8 @@ jobs:
           REF_SHORT=${REF_SHORT#refs/tags/}
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=ref_short::$REF_SHORT"
-          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          #echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          echo "::set-output name=ref_hash::${GITHUB_SHA::7}"
       - name: setup Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - run: |
@@ -260,7 +262,8 @@ jobs:
           REF_SHORT=${REF_SHORT#refs/tags/}
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=ref_short::$REF_SHORT"
-          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          #echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          echo "::set-output name=ref_hash::${GITHUB_SHA::7}"
       - run: |
           export SDL_VERSION="2.0.16"
           export SDL_TTF_VERSION="2.0.15"
@@ -291,7 +294,8 @@ jobs:
           REF_SHORT=${REF_SHORT#refs/tags/}
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=ref_short::$REF_SHORT"
-          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          #echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          echo "::set-output name=ref_hash::${GITHUB_SHA::7}"
       - run: |
           export SDL_VERSION="2.0.16"
           export SDL_TTF_VERSION="2.0.15"
@@ -327,7 +331,8 @@ jobs:
           REF_SHORT=${REF_SHORT#refs/tags/}
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=ref_short::$REF_SHORT"
-          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          #echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          echo "::set-output name=ref_hash::${GITHUB_SHA::7}"
       - uses: actions/setup-java@v1
         with:
           java-version: 8
@@ -438,7 +443,8 @@ jobs:
           REF_SHORT=${REF_SHORT#refs/tags/}
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=ref_short::$REF_SHORT"
-          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA}"
+          #echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA}"
+          echo "::set-output name=ref_hash::${GITHUB_SHA}"
       - name: apt-get install build deps
         run: |
           apt-get update -qq
@@ -527,7 +533,8 @@ jobs:
           REF_SHORT=${REF_SHORT#refs/tags/}
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=ref_short::$REF_SHORT"
-          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          #echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          echo "::set-output name=ref_hash::${GITHUB_SHA::7}"
       - name: apt-get install build deps
         run: |
           sudo apt-get update -qq
@@ -559,7 +566,8 @@ jobs:
           REF_SHORT=${REF_SHORT#refs/tags/}
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=ref_short::$REF_SHORT"
-          echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          #echo "::set-output name=ref_hash::${REF_SHORT}-${GITHUB_SHA::7}"
+          echo "::set-output name=ref_hash::${GITHUB_SHA::7}"
       - name: apt-get install build deps
         run: |
           sudo apt-get update -qq

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -304,11 +304,10 @@ jobs:
           tar -xzf SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
           # Same for SDL2_ttf, let's strip away version number
           mv SDL2_ttf-${SDL_TTF_VERSION} SDL2_ttf
-          # Hack for newer SDL versions
-          # cp -r SDL/Xcode/SDL/SDL.xcodeproj SDL/XCode-iOS/SDL/.
+          # list possible schemes/targets
           xcodebuild -project SDL/Xcode/SDL/SDL.xcodeproj -list
       - run: |
-          cd build/xcode-ios
+          cd build/xcode12-ios
           xcodebuild -project mangclient-ios.xcodeproj -list
           xcodebuild -project mangclient-ios.xcodeproj -scheme "Static Library-iOS" CONFIGURATION_BUILD_DIR="./build/Debug" -configuration Debug ONLY_ACTIVE_ARCH="YES"
           xcodebuild -project mangclient-ios.xcodeproj -scheme "libSDL_ttf-iOS" CONFIGURATION_BUILD_DIR="./build/Debug-iphoneos" -configuration Debug ONLY_ACTIVE_ARCH="YES" -destination generic/platform=iOS

--- a/build/xcode12-ios/mangclient-ios.xcodeproj/project.pbxproj
+++ b/build/xcode12-ios/mangclient-ios.xcodeproj/project.pbxproj
@@ -45,7 +45,6 @@
 		2E0078352301792300DD2D1A /* set_focus.c in Sources */ = {isa = PBXBuildFile; fileRef = 2E0078132301792200DD2D1A /* set_focus.c */; };
 		2E0078372301792300DD2D1A /* c-xtra2.c in Sources */ = {isa = PBXBuildFile; fileRef = 2E0078162301792200DD2D1A /* c-xtra2.c */; };
 		2E22CDF2230152A600CDE5A4 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E22CDE8230152A600CDE5A4 /* Metal.framework */; };
-		2E29DE36230181A600415961 /* libSDL2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E29DE2B2301816100415961 /* libSDL2.a */; };
 		2E29DE3B230183B500415961 /* miniz.c in Sources */ = {isa = PBXBuildFile; fileRef = 2E29DE38230183B400415961 /* miniz.c */; };
 		2E29DE3C230183B500415961 /* lupng.c in Sources */ = {isa = PBXBuildFile; fileRef = 2E29DE3A230183B500415961 /* lupng.c */; };
 		2E29DE5823018B4900415961 /* xtra in Resources */ = {isa = PBXBuildFile; fileRef = 2E29DE5723018B4900415961 /* xtra */; };
@@ -61,57 +60,17 @@
 		2E9B33432405A116003E24BD /* base64encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 2E9B33412405A116003E24BD /* base64encode.c */; };
 		2EA8D715230D55D700EBF4A1 /* libSDL2_ttf.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2EA8D710230D557800EBF4A1 /* libSDL2_ttf.a */; };
 		2EB388BA230401E6007B7A33 /* appl-dir.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EB388B8230401E6007B7A33 /* appl-dir.m */; };
+		2ED7030527121F6500222FEA /* libSDL2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ED702F027121F5F00222FEA /* libSDL2.a */; };
 		2EE023F123009C0B00BA0836 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2EE023DD23009C0B00BA0836 /* AVFoundation.framework */; };
 		FA8B4B97196703B400F8EB7C /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA8B4B96196703B400F8EB7C /* CoreMotion.framework */; };
 		FAE0E9651BAF967F0098DFA4 /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAE0E9641BAF967F0098DFA4 /* GameController.framework */; };
 		FD779EDE0E26BA1200F39101 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD779EDD0E26BA1200F39101 /* CoreAudio.framework */; };
+		FD779EDE0E26BA1200F39102 /* CoreHaptics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD779EDD0E26BA1200F39102 /* CoreHaptics.framework */; };
 		FD77A0850E26BDB800F39101 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD77A0840E26BDB800F39101 /* AudioToolbox.framework */; };
 		FDB8BFC60E5A0F6A00980157 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FDB8BFC50E5A0F6A00980157 /* CoreGraphics.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		2E29DE2A2301816100415961 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = FD6526630DE8FCCB002AD96B;
-			remoteInfo = "libSDL-iOS";
-		};
-		2E29DE2C2301816100415961 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 52ED1E5C222889500061FCE0;
-			remoteInfo = "libSDL-iOS-dylib";
-		};
-		2E29DE2E2301816100415961 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = FAB598141BB5C1B100BE72C5;
-			remoteInfo = "libSDL-tvOS";
-		};
-		2E29DE302301816100415961 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F3E3C7572241389A007D243C;
-			remoteInfo = "libSDL-tvOS-dylib";
-		};
-		2E29DE322301816100415961 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F3E3C65222406928007D243C;
-			remoteInfo = "libSDLmain-iOS";
-		};
-		2E29DE342301816100415961 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F3E3C75F224138AE007D243C;
-			remoteInfo = "libSDLmain-tvOS";
-		};
 		2EA8D70F230D557800EBF4A1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */;
@@ -125,6 +84,111 @@
 			proxyType = 2;
 			remoteGlobalIDString = AA53152E1FE1016F0025C9BE;
 			remoteInfo = "libSDL_ttf-tvOS";
+		};
+		2ED702E327121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F3CB94BA26B5E0A400B9C980;
+			remoteInfo = "SDLmain-iOS";
+		};
+		2ED702E527121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F3CB963826B5E0A600B9C980;
+			remoteInfo = "SDLmain-tvOS";
+		};
+		2ED702E727121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = BECDF66C0761BA81005FE872;
+			remoteInfo = Framework;
+		};
+		2ED702E927121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A7D88B5423E2437C00DCD162;
+			remoteInfo = "Framework-iOS";
+		};
+		2ED702EB27121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A7D88D1523E24BED00DCD162;
+			remoteInfo = "Framework-tvOS";
+		};
+		2ED702ED27121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = BECDF6B30761BA81005FE872;
+			remoteInfo = "Static Library";
+		};
+		2ED702EF27121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A7D88E5423E24D3B00DCD162;
+			remoteInfo = "Static Library-iOS";
+		};
+		2ED702F127121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A769B23D23E259AE00872273;
+			remoteInfo = "Static Library-tvOS";
+		};
+		2ED702F327121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = DB31407717554B71006C0E22;
+			remoteInfo = "Shared Library";
+		};
+		2ED702F527121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A75FCEB323E25AB700529352;
+			remoteInfo = "Shared Library-iOS";
+		};
+		2ED702F727121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A75FD06C23E25AC700529352;
+			remoteInfo = "Shared Library-tvOS";
+		};
+		2ED702F927121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = BECDF6BE0761BA81005FE872;
+			remoteInfo = "Standard DMG";
+		};
+		2ED702FB27121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A75FDB8C23E4C74400529352;
+			remoteInfo = hidapi;
+		};
+		2ED702FD27121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A75FDB4923E399AC00529352;
+			remoteInfo = "hidapi-iOS";
+		};
+		2ED702FF27121F5F00222FEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E29DE1E2301816000415961 /* SDL.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A75FDB6E23E3A2C900529352;
+			remoteInfo = "hidapi-tvOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -198,7 +262,7 @@
 		2E0078152301792200DD2D1A /* sdl-font.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "sdl-font.h"; path = "../../src/client/sdl-font.h"; sourceTree = "<group>"; };
 		2E0078162301792200DD2D1A /* c-xtra2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "c-xtra2.c"; path = "../../src/client/c-xtra2.c"; sourceTree = "<group>"; };
 		2E22CDE8230152A600CDE5A4 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
-		2E29DE1E2301816000415961 /* SDL.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SDL.xcodeproj; path = "../../../SDL/Xcode-iOS/SDL/SDL.xcodeproj"; sourceTree = "<group>"; };
+		2E29DE1E2301816000415961 /* SDL.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SDL.xcodeproj; path = ../../../SDL/Xcode/SDL/SDL.xcodeproj; sourceTree = "<group>"; };
 		2E29DE37230183B400415961 /* lupng.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lupng.h; path = ../../src/client/lupng/lupng.h; sourceTree = "<group>"; };
 		2E29DE38230183B400415961 /* miniz.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = miniz.c; path = ../../src/client/lupng/miniz.c; sourceTree = "<group>"; };
 		2E29DE39230183B400415961 /* miniz.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = miniz.h; path = ../../src/client/lupng/miniz.h; sourceTree = "<group>"; };
@@ -226,6 +290,7 @@
 		FA8B4B96196703B400F8EB7C /* CoreMotion.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMotion.framework; path = System/Library/Frameworks/CoreMotion.framework; sourceTree = SDKROOT; };
 		FAE0E9641BAF967F0098DFA4 /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = System/Library/Frameworks/GameController.framework; sourceTree = SDKROOT; };
 		FD779EDD0E26BA1200F39101 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		FD779EDD0E26BA1200F39102 /* CoreHaptics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreHaptics.framework; path = System/Library/Frameworks/CoreHaptics.framework; sourceTree = SDKROOT; };
 		FD77A0840E26BDB800F39101 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		FDB8BFC50E5A0F6A00980157 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -235,7 +300,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2E29DE36230181A600415961 /* libSDL2.a in Frameworks */,
+				2ED7030527121F6500222FEA /* libSDL2.a in Frameworks */,
 				2EA8D715230D55D700EBF4A1 /* libSDL2_ttf.a in Frameworks */,
 				2E975A672420A810009B2190 /* CoreBluetooth.framework in Frameworks */,
 				2E22CDF2230152A600CDE5A4 /* Metal.framework in Frameworks */,
@@ -246,6 +311,7 @@
 				28FD15000DC6FC520079059D /* OpenGLES.framework in Frameworks */,
 				28FD15080DC6FC5B0079059D /* QuartzCore.framework in Frameworks */,
 				FD779EDE0E26BA1200F39101 /* CoreAudio.framework in Frameworks */,
+				FD779EDE0E26BA1200F39102 /* CoreHaptics.framework in Frameworks */,
 				FD77A0850E26BDB800F39101 /* AudioToolbox.framework in Frameworks */,
 				FDB8BFC60E5A0F6A00980157 /* CoreGraphics.framework in Frameworks */,
 				FA8B4B97196703B400F8EB7C /* CoreMotion.framework in Frameworks */,
@@ -348,6 +414,7 @@
 				FDB8BFC50E5A0F6A00980157 /* CoreGraphics.framework */,
 				FD77A0840E26BDB800F39101 /* AudioToolbox.framework */,
 				FD779EDD0E26BA1200F39101 /* CoreAudio.framework */,
+				FD779EDD0E26BA1200F39102 /* CoreHaptics.framework */,
 				28FD15070DC6FC5B0079059D /* QuartzCore.framework */,
 				28FD14FF0DC6FC520079059D /* OpenGLES.framework */,
 				1DF5F4DF0D08C38300B7A737 /* UIKit.framework */,
@@ -359,12 +426,21 @@
 		2E29DE1F2301816000415961 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				2E29DE2B2301816100415961 /* libSDL2.a */,
-				2E29DE2D2301816100415961 /* libSDL2.dylib */,
-				2E29DE2F2301816100415961 /* libSDL2.a */,
-				2E29DE312301816100415961 /* libSDL2.dylib */,
-				2E29DE332301816100415961 /* libSDLmain.a */,
-				2E29DE352301816100415961 /* libSDLmain.a */,
+				2ED702E427121F5F00222FEA /* libSDLmain.a */,
+				2ED702E627121F5F00222FEA /* libSDLmain.a */,
+				2ED702E827121F5F00222FEA /* SDL2.framework */,
+				2ED702EA27121F5F00222FEA /* SDL2.framework */,
+				2ED702EC27121F5F00222FEA /* SDL2.framework */,
+				2ED702EE27121F5F00222FEA /* libSDL2.a */,
+				2ED702F027121F5F00222FEA /* libSDL2.a */,
+				2ED702F227121F5F00222FEA /* libSDL2.a */,
+				2ED702F427121F5F00222FEA /* libSDL2.dylib */,
+				2ED702F627121F5F00222FEA /* libSDL2.dylib */,
+				2ED702F827121F5F00222FEA /* libSDL2.dylib */,
+				2ED702FA27121F5F00222FEA /* SDL2 */,
+				2ED702FC27121F5F00222FEA /* hidapi.framework */,
+				2ED702FE27121F5F00222FEA /* hidapi.framework */,
+				2ED7030027121F5F00222FEA /* hidapi.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -486,48 +562,6 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		2E29DE2B2301816100415961 /* libSDL2.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libSDL2.a;
-			remoteRef = 2E29DE2A2301816100415961 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		2E29DE2D2301816100415961 /* libSDL2.dylib */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libSDL2.dylib;
-			remoteRef = 2E29DE2C2301816100415961 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		2E29DE2F2301816100415961 /* libSDL2.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libSDL2.a;
-			remoteRef = 2E29DE2E2301816100415961 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		2E29DE312301816100415961 /* libSDL2.dylib */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libSDL2.dylib;
-			remoteRef = 2E29DE302301816100415961 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		2E29DE332301816100415961 /* libSDLmain.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libSDLmain.a;
-			remoteRef = 2E29DE322301816100415961 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		2E29DE352301816100415961 /* libSDLmain.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libSDLmain.a;
-			remoteRef = 2E29DE342301816100415961 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		2EA8D710230D557800EBF4A1 /* libSDL2_ttf.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -540,6 +574,111 @@
 			fileType = archive.ar;
 			path = libSDL2_ttf.a;
 			remoteRef = 2EA8D711230D557800EBF4A1 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702E427121F5F00222FEA /* libSDLmain.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSDLmain.a;
+			remoteRef = 2ED702E327121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702E627121F5F00222FEA /* libSDLmain.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSDLmain.a;
+			remoteRef = 2ED702E527121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702E827121F5F00222FEA /* SDL2.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SDL2.framework;
+			remoteRef = 2ED702E727121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702EA27121F5F00222FEA /* SDL2.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SDL2.framework;
+			remoteRef = 2ED702E927121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702EC27121F5F00222FEA /* SDL2.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SDL2.framework;
+			remoteRef = 2ED702EB27121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702EE27121F5F00222FEA /* libSDL2.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSDL2.a;
+			remoteRef = 2ED702ED27121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702F027121F5F00222FEA /* libSDL2.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSDL2.a;
+			remoteRef = 2ED702EF27121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702F227121F5F00222FEA /* libSDL2.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSDL2.a;
+			remoteRef = 2ED702F127121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702F427121F5F00222FEA /* libSDL2.dylib */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.dylib";
+			path = libSDL2.dylib;
+			remoteRef = 2ED702F327121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702F627121F5F00222FEA /* libSDL2.dylib */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.dylib";
+			path = libSDL2.dylib;
+			remoteRef = 2ED702F527121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702F827121F5F00222FEA /* libSDL2.dylib */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.dylib";
+			path = libSDL2.dylib;
+			remoteRef = 2ED702F727121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702FA27121F5F00222FEA /* SDL2 */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.executable";
+			path = SDL2;
+			remoteRef = 2ED702F927121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702FC27121F5F00222FEA /* hidapi.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = hidapi.framework;
+			remoteRef = 2ED702FB27121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED702FE27121F5F00222FEA /* hidapi.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = hidapi.framework;
+			remoteRef = 2ED702FD27121F5F00222FEA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2ED7030027121F5F00222FEA /* hidapi.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = hidapi.framework;
+			remoteRef = 2ED702FF27121F5F00222FEA /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -730,6 +869,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "";
 				SDKROOT = iphoneos;
 			};

--- a/src/client/osx/Makefile.am
+++ b/src/client/osx/Makefile.am
@@ -48,7 +48,7 @@ mangclient.app: mangclient
 			fi ; \
 		done ; \
 	done
-	@chmod -w mangclient.app/Contents/MacOS/*.dylib ; \
+	@chmod -w mangclient.app/Contents/MacOS/*.dylib
 	@cp src/client/osx/launch_mangclient.sh mangclient.app/Contents/MacOS
 	@cp src/client/osx/mangclient.icns mangclient.app/Contents/Resources
 	@cp src/client/osx/Info.plist mangclient.app/Contents


### PR DESCRIPTION
This PR adds new CI/CD scripts, using GitHub actions.

The intention here is to drop support for Travis-CI and/or appveyor; and move everything to github. You can already see this workflow in action, by clicking on the `Checks (13)` tab right in the Pull Request.

The checks are:
- `vs2017` - our vs2017 project still works
- `xcode` - our macOS xcode project still works
- `linux` - X11/GCU/SDL/SDL2 on linux works
- `ios` - our iOS xcode project still works
- `android` - build debug apks
- `appimage` - build appimages
- `win32` - build win distributions using MSYS2
- `osx64` - build osx distributions using command-line tools

Note: all "nightly" builds are posted to `<owner>/mangband-builds` (e.g. `mangband/mangband`, in case our repo), thus you must create a PAT with access to such a repository. For this repo, I'm reusing `mangbot` github account, which did similar things on appveyor and travis. Forked repositories (if they are interested in similar CI/CD), will have to set this up.

Note2: MSYS2 makes a major comeback, being the simpliest tool to compile mangband on windows. The plan here is to switch back to MSYS2-based builds for release distributions (we did it like that for like 10 latest releases, except the 1.5.3 one, which was build in Visual Studio, and requires MSVC++ redistributable, yuck).