### PR TITLE
Update URLs of SDL_ttf release assets used in our CI/CD.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -266,9 +266,9 @@ jobs:
           echo "::set-output name=ref_hash::${GITHUB_SHA::7}"
       - run: |
           export SDL_VERSION="2.0.16"
-          export SDL_TTF_VERSION="2.0.15"
+          export SDL_TTF_VERSION="2.0.18"
           curl -O http://libsdl.org/release/SDL2-${SDL_VERSION}.dmg
-          curl -O https://www.libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.dmg
+          curl -OL https://github.com/libsdl-org/SDL_ttf/releases/download/release-${SDL_TTF_VERSION}/SDL2_ttf-${SDL_TTF_VERSION}.dmg
           hdiutil attach SDL2-${SDL_VERSION}.dmg
           hdiutil attach SDL2_ttf-${SDL_TTF_VERSION}.dmg
           cp -r /Volumes/SDL2/SDL2.framework build/xcode/.
@@ -298,23 +298,24 @@ jobs:
           echo "::set-output name=ref_hash::${GITHUB_SHA::7}"
       - run: |
           export SDL_VERSION="2.0.16"
-          export SDL_TTF_VERSION="2.0.15"
+          export SDL_TTF_VERSION="2.0.18"
           cd ..
           curl -O https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
           tar -xzf SDL2-${SDL_VERSION}.tar.gz
           # Our xcode project expects to find "SDL" dir, not "SDL2-2.X.Y"
           mv SDL2-${SDL_VERSION} SDL
-          curl -O https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
+          curl -OL https://github.com/libsdl-org/SDL_ttf/releases/download/release-${SDL_TTF_VERSION}/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
           tar -xzf SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
           # Same for SDL2_ttf, let's strip away version number
           mv SDL2_ttf-${SDL_TTF_VERSION} SDL2_ttf
           # list possible schemes/targets
           xcodebuild -project SDL/Xcode/SDL/SDL.xcodeproj -list
+          xcodebuild -project SDL2_ttf/Xcode/SDL_ttf.xcodeproj -list
       - run: |
           cd build/xcode12-ios
           xcodebuild -project mangclient-ios.xcodeproj -list
-          xcodebuild -project mangclient-ios.xcodeproj -scheme "Static Library-iOS" CONFIGURATION_BUILD_DIR="./build/Debug" -configuration Debug ONLY_ACTIVE_ARCH="YES"
-          xcodebuild -project mangclient-ios.xcodeproj -scheme "libSDL_ttf-iOS" CONFIGURATION_BUILD_DIR="./build/Debug-iphoneos" -configuration Debug ONLY_ACTIVE_ARCH="YES" -destination generic/platform=iOS
+          xcodebuild -project ../../../SDL/Xcode/SDL/SDL.xcodeproj -scheme "Static Library-iOS" CONFIGURATION_BUILD_DIR="./build/Debug" -configuration Debug ONLY_ACTIVE_ARCH="YES"
+          xcodebuild -project ../../../SDL2_ttf/Xcode/SDL_ttf.xcodeproj -scheme "Static Library-iOS" CONFIGURATION_BUILD_DIR="./build/Debug" -configuration Debug ONLY_ACTIVE_ARCH="YES" -destination generic/platform=iOS
           xcodebuild -project mangclient-ios.xcodeproj build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED="NO" CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO" -configuration Debug ONLY_ACTIVE_ARCH="YES"
   android:
     runs-on: ubuntu-latest
@@ -345,13 +346,13 @@ jobs:
         shell: bash
         run: |
          export SDL_VERSION="2.0.10"
-         export SDL_TTF_VERSION="2.0.15"
+         export SDL_TTF_VERSION="2.0.18"
          cd build/asgradle
          wget https://libsdl.org/release/SDL2-${SDL_VERSION}.tar.gz
          tar -xzf SDL2-${SDL_VERSION}.tar.gz
          cp -r SDL2-${SDL_VERSION}/android-project/gradle .
          mv SDL2-${SDL_VERSION} mangclient/jni/SDL2
-         wget https://libsdl.org/tmp/SDL_ttf/release/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
+         wget https://github.com/libsdl-org/SDL_ttf/releases/download/release-${SDL_TTF_VERSION}/SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
          tar -xzf SDL2_ttf-${SDL_TTF_VERSION}.tar.gz
          mv SDL2_ttf-${SDL_TTF_VERSION} mangclient/jni/SDL2_ttf
          ln -s ../../../../../../lib mangclient/src/main/assets/lib

--- a/build/xcode-ios/mangclient-ios.xcodeproj/project.pbxproj
+++ b/build/xcode-ios/mangclient-ios.xcodeproj/project.pbxproj
@@ -218,7 +218,7 @@
 		2E9B333F2405A116003E24BD /* base64encode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = base64encode.h; path = ../../src/common/base64encode.h; sourceTree = "<group>"; };
 		2E9B33402405A116003E24BD /* sha1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sha1.c; path = ../../src/common/sha1.c; sourceTree = "<group>"; };
 		2E9B33412405A116003E24BD /* base64encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = base64encode.c; path = ../../src/common/base64encode.c; sourceTree = "<group>"; };
-		2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SDL_ttf.xcodeproj; path = "../../../SDL2_ttf/Xcode-iOS/SDL_ttf.xcodeproj"; sourceTree = "<group>"; };
+		2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SDL_ttf.xcodeproj; path = ../../../SDL2_ttf/SDL_ttf.xcodeproj; sourceTree = "<group>"; };
 		2EB388B8230401E6007B7A33 /* appl-dir.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "appl-dir.m"; path = "../../src/client/osx/appl-dir.m"; sourceTree = "<group>"; };
 		2EB388B9230401E6007B7A33 /* appl-dir.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "appl-dir.h"; path = "../../src/client/osx/appl-dir.h"; sourceTree = "<group>"; };
 		2EB388BB23040212007B7A33 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -630,6 +630,7 @@
 				INFOPLIST_FILE = ../../src/client/ios/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				"OTHER_LDFLAGS[arch=*]" = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.mangband.client-sdl2";
 				PRODUCT_NAME = "mangclient-ios";
 				SYSTEM_HEADER_SEARCH_PATHS = "../../../SDL/include ../../../SDL2_ttf";
@@ -655,6 +656,7 @@
 				INFOPLIST_FILE = ../../src/client/ios/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				"OTHER_LDFLAGS[arch=*]" = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.mangband.client-sdl2";
 				PRODUCT_NAME = "mangclient-ios";
 				SYSTEM_HEADER_SEARCH_PATHS = "../../../SDL/include ../../../SDL2_ttf";

--- a/build/xcode12-ios/mangclient-ios.xcodeproj/project.pbxproj
+++ b/build/xcode12-ios/mangclient-ios.xcodeproj/project.pbxproj
@@ -71,19 +71,54 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2EA25FBD27DD252500230357 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = BE48FD6707AFA17000BB41DA;
+			remoteInfo = Framework;
+		};
+		2EA25FBF27DD252500230357 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A75FDAF323E3582C00529352;
+			remoteInfo = "Framework-iOS";
+		};
+		2EA25FC127DD252500230357 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A75FDB0A23E36B4300529352;
+			remoteInfo = "Framework-tvOS";
+		};
+		2EA25FC327DD252500230357 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A75FDB2E23E3825200529352;
+			remoteInfo = "Static Library-iOS";
+		};
+		2EA25FC527DD252500230357 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A75FDB3923E3827100529352;
+			remoteInfo = "Static Library-tvOS";
+		};
+		2EA25FC727DD252500230357 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = BE48FD7207AFA17000BB41DA;
+			remoteInfo = "Create DMG";
+		};
 		2EA8D70F230D557800EBF4A1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = BE48FD6E07AFA17000BB41DA;
 			remoteInfo = "libSDL_ttf-iOS";
-		};
-		2EA8D711230D557800EBF4A1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = AA53152E1FE1016F0025C9BE;
-			remoteInfo = "libSDL_ttf-tvOS";
 		};
 		2ED702E327121F5F00222FEA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -282,7 +317,7 @@
 		2E9B333F2405A116003E24BD /* base64encode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = base64encode.h; path = ../../src/common/base64encode.h; sourceTree = "<group>"; };
 		2E9B33402405A116003E24BD /* sha1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sha1.c; path = ../../src/common/sha1.c; sourceTree = "<group>"; };
 		2E9B33412405A116003E24BD /* base64encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = base64encode.c; path = ../../src/common/base64encode.c; sourceTree = "<group>"; };
-		2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SDL_ttf.xcodeproj; path = "../../../SDL2_ttf/Xcode-iOS/SDL_ttf.xcodeproj"; sourceTree = "<group>"; };
+		2EB0B0122306F644003B13E7 /* SDL_ttf.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SDL_ttf.xcodeproj; path = ../../../SDL2_ttf/Xcode/SDL_ttf.xcodeproj; sourceTree = "<group>"; };
 		2EB388B8230401E6007B7A33 /* appl-dir.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "appl-dir.m"; path = "../../src/client/osx/appl-dir.m"; sourceTree = "<group>"; };
 		2EB388B9230401E6007B7A33 /* appl-dir.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "appl-dir.h"; path = "../../src/client/osx/appl-dir.h"; sourceTree = "<group>"; };
 		2EB388BB23040212007B7A33 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -493,8 +528,13 @@
 		2EA8D6FF230D557700EBF4A1 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				2EA25FBE27DD252500230357 /* SDL2_ttf.framework */,
+				2EA25FC027DD252500230357 /* SDL2_ttf.framework */,
+				2EA25FC227DD252500230357 /* SDL2_ttf.framework */,
 				2EA8D710230D557800EBF4A1 /* libSDL2_ttf.a */,
-				2EA8D712230D557800EBF4A1 /* libSDL2_ttf.a */,
+				2EA25FC427DD252500230357 /* libSDL2_ttf.a */,
+				2EA25FC627DD252500230357 /* libSDL2_ttf.a */,
+				2EA25FC827DD252500230357 /* Create DMG */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -562,18 +602,53 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		2EA25FBE27DD252500230357 /* SDL2_ttf.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SDL2_ttf.framework;
+			remoteRef = 2EA25FBD27DD252500230357 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2EA25FC027DD252500230357 /* SDL2_ttf.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SDL2_ttf.framework;
+			remoteRef = 2EA25FBF27DD252500230357 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2EA25FC227DD252500230357 /* SDL2_ttf.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SDL2_ttf.framework;
+			remoteRef = 2EA25FC127DD252500230357 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2EA25FC427DD252500230357 /* libSDL2_ttf.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSDL2_ttf.a;
+			remoteRef = 2EA25FC327DD252500230357 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2EA25FC627DD252500230357 /* libSDL2_ttf.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSDL2_ttf.a;
+			remoteRef = 2EA25FC527DD252500230357 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2EA25FC827DD252500230357 /* Create DMG */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.executable";
+			path = "Create DMG";
+			remoteRef = 2EA25FC727DD252500230357 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		2EA8D710230D557800EBF4A1 /* libSDL2_ttf.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libSDL2_ttf.a;
 			remoteRef = 2EA8D70F230D557800EBF4A1 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		2EA8D712230D557800EBF4A1 /* libSDL2_ttf.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libSDL2_ttf.a;
-			remoteRef = 2EA8D711230D557800EBF4A1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		2ED702E427121F5F00222FEA /* libSDLmain.a */ = {
@@ -769,6 +844,7 @@
 				INFOPLIST_FILE = ../../src/client/ios/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				"OTHER_LDFLAGS[arch=*]" = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.mangband.client-sdl2";
 				PRODUCT_NAME = "mangclient-ios";
 				SYSTEM_HEADER_SEARCH_PATHS = "../../../SDL/include ../../../SDL2_ttf";
@@ -794,6 +870,7 @@
 				INFOPLIST_FILE = ../../src/client/ios/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				"OTHER_LDFLAGS[arch=*]" = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.mangband.client-sdl2";
 				PRODUCT_NAME = "mangclient-ios";
 				SYSTEM_HEADER_SEARCH_PATHS = "../../../SDL/include ../../../SDL2_ttf";


### PR DESCRIPTION
SDL_ttf is now hosted on github https://github.com/libsdl-org/SDL_ttf/releases and the old download URLs no longer work.

For iOS, even more changes are required, as old releases of SDL2_ttf are no longer available anywhere. The latest available release in 2.0.18, which we're going to migrate to, which:
- changes XCode project structure a bit, and the build target is now called "Static Library-iOS" (similarly to the build target in the SDL2.xcodeproject)
- thus, to distinguish between the two, we now reference SDL2_ttf.xcodeproject directly in the CI script
- SDL2_ttf now also bundles harfbuzz library, which contains C++ code, so we also need to add `-lc++` linker flag, to provide some cpp stdlib bits